### PR TITLE
feat: integrate go_router for improved navigation and update README f…

### DIFF
--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -1,20 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:springster_example/main.dart';
-import 'package:superhero/superhero.dart';
 import 'package:superhero_example/main.dart';
 
 void main() async {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const Home(),
+      ),
+      GoRoute(
+        path: '/superhero',
+        builder: (context, state) => const SuperheroExampleApp(),
+      ),
+      GoRoute(
+        path: '/springster',
+        builder: (context, state) => const SpringsterExampleApp(),
+      ),
+    ],
+  );
+
   runApp(
-    MaterialApp(
+    MaterialApp.router(
       color: Colors.blue,
       debugShowCheckedModeBanner: false,
-      initialRoute: '/',
-      routes: {
-        '/': (context) => const Home(),
-        '/superhero': (context) => const SuperheroExampleApp(),
-        '/springster': (context) => const SpringsterExampleApp(),
-      },
-      navigatorObservers: [SuperheroController()],
+      routerConfig: router,
     ),
   );
 }
@@ -36,11 +47,11 @@ class Home extends StatelessWidget {
           mainAxisSpacing: 16,
           children: [
             FilledButton.tonal(
-              onPressed: () => Navigator.pushNamed(context, '/superhero'),
+              onPressed: () => context.go('/superhero'),
               child: const Text('Superhero'),
             ),
             FilledButton.tonal(
-              onPressed: () => Navigator.pushNamed(context, '/springster'),
+              onPressed: () => context.go('/springster'),
               child: const Text('Springster'),
             ),
           ],

--- a/apps/example/pubspec.yaml
+++ b/apps/example/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 
 
   rivership: ^0.1.3+2
+  go_router: ^14.6.3
 
   
 

--- a/packages/springster/README.md
+++ b/packages/springster/README.md
@@ -5,7 +5,6 @@
 
 Spring animations and simulations, simplified.
 
-> Partially adapted from and heavily inspired by [fluid_animations](https://pub.dev/packages/fluid_animations).
 
 ## Features 🎯
 
@@ -13,6 +12,9 @@ Spring animations and simulations, simplified.
 - 🔄 Spring-based draggable widgets with smooth return animations
 - 🎯 Spring curves for use with standard Flutter animations
 - 📱 2D spring animations for complex movements
+
+## Try it out
+[Open Example](https://whynotmake.it/rivership/springster)
 
 ## Installation 💻
 
@@ -133,7 +135,11 @@ const mySpring = SimpleSpring.withDamping(
 );
 ```
 
+---
 
+## Acknowledgements
+
+Springster was partially adapted from and heavily inspired by [fluid_animations](https://pub.dev/packages/fluid_animations).
 
 [dart_install_link]: https://dart.dev/get-dart
 [mason_link]: https://github.com/felangel/mason

--- a/packages/superhero/README.md
+++ b/packages/superhero/README.md
@@ -6,6 +6,10 @@
 
 An evolution on Heroes in Flutter, supporting Spring-based animations as well as cleaner route transitions.
 
+## Try it out
+
+[Open Example](https://whynotmake.it/rivership/superhero)
+
 ## Installation 💻
 
 **❗ In order to start using Superhero you must have the [Flutter SDK][flutter_install_link] installed on your machine.**

--- a/packages/superhero/example/lib/main.dart
+++ b/packages/superhero/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:superhero_example/src/settings_menus.dart';
 import 'package:figma_squircle_updated/figma_squircle.dart';
 import 'package:flutter/cupertino.dart';
@@ -158,6 +159,7 @@ class Cover extends StatelessWidget {
                 : DecorationImage(
                     image: CachedNetworkImageProvider(
                       'https://picsum.photos/800/800?random=$index',
+                      imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
                     ),
                     fit: BoxFit.cover,
                   ),


### PR DESCRIPTION
…iles with example links

- Added go_router dependency to pubspec.yaml.
- Refactored main.dart to use MaterialApp.router with GoRouter for route management.
- Updated navigation methods to use context.go() for better performance.
- Enhanced README.md files for both springster and superhero packages with example links for easier access.

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
