### PR TITLE
fix: update intl dependency

### DIFF
--- a/packages/rivership/pubspec.yaml
+++ b/packages/rivership/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_hooks: ">=0.20.5 <0.22.0"
   heroine: ^0.5.0-dev.3
   hooks_riverpod: ">=2.6.1 <3.0.0"
-  intl: ">=0.19.0 <0.20.0"
+  intl: ">=0.19.0 <0.21.0"
   material_color_utilities: ">=0.8.0 <0.12.0"
   springster: ^1.0.0-dev.3
 


### PR DESCRIPTION
## Description

Flutter 3.32.0 depends on intl 0.20.x. As there are no breaking changes in 0.20, let's loosen the version requirement to include all 0.20 versions.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
