### PR TITLE
fix!: don't call `Navigator.did[Start|Stop]UserGesture` by default to…

### DIFF
--- a/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
@@ -21,6 +21,7 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
     ),
     this.clearBarrierImmediately = true,
     this.backgroundColor = CupertinoColors.systemBackground,
+    this.callNavigatorUserGestureMethods = false,
     this.snappingConfig = const SheetSnappingConfig.relative([1.0]),
   });
 
@@ -59,6 +60,9 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
 
   @override
   bool get opaque => false;
+
+  @override
+  final bool callNavigatorUserGestureMethods;
 
   @override
   final SheetSnappingConfig snappingConfig;

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -47,6 +47,7 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
     this.clipBehavior = Clip.antiAlias,
     this.clearBarrierImmediately = true,
     this.onlyDragWhenScrollWasAtTop = true,
+    this.callNavigatorUserGestureMethods = false,
     this.snappingConfig = const SheetSnappingConfig.relative([1.0]),
   });
 
@@ -83,6 +84,9 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
 
   @override
   final bool onlyDragWhenScrollWasAtTop;
+
+  @override
+  final bool callNavigatorUserGestureMethods;
 
   /// The snapping configuration for the sheet.
   @override
@@ -182,6 +186,12 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
   /// This matches iOS sheet behavior and defaults to true.
   /// {@endtemplate}
   bool get onlyDragWhenScrollWasAtTop => true;
+
+  /// Whether the navigator's user gesture methods should be called when
+  /// dragging starts and ends.
+  ///
+  /// Defaults to false.
+  bool get callNavigatorUserGestureMethods => false;
 
   /// The snapping configuration for the sheet.
   ///
@@ -328,7 +338,9 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
   void _handleDragStart(
     BuildContext context,
   ) {
-    Navigator.of(context).didStartUserGesture();
+    if (callNavigatorUserGestureMethods) {
+      Navigator.of(context).didStartUserGesture();
+    }
   }
 
   void _handleDragUpdate(BuildContext context, double delta) {
@@ -354,7 +366,9 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
     double velocity,
   ) {
     final currentValue = controller!.value;
-    Navigator.of(context).didStopUserGesture();
+    if (callNavigatorUserGestureMethods) {
+      Navigator.of(context).didStopUserGesture();
+    }
 
     _dragEndVelocity = velocity;
 


### PR DESCRIPTION
… match Flutter sheets.

You can restore the old behavior by passing `callNavigatorUserGestureMethods = true` to your sheet route

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
