### PR TITLE
feat!: allow overriding the current sheet's snapping config from its controller

### DIFF
--- a/packages/stupid_simple_sheet/example/lib/main.dart
+++ b/packages/stupid_simple_sheet/example/lib/main.dart
@@ -159,8 +159,15 @@ class _CupertinoSheetContent extends StatelessWidget {
   }
 }
 
-class _SnappingSheetContent extends StatelessWidget {
+class _SnappingSheetContent extends StatefulWidget {
   const _SnappingSheetContent();
+
+  @override
+  State<_SnappingSheetContent> createState() => _SnappingSheetContentState();
+}
+
+class _SnappingSheetContentState extends State<_SnappingSheetContent> {
+  bool _snapDisabled = false;
 
   @override
   Widget build(BuildContext context) {
@@ -169,6 +176,22 @@ class _SnappingSheetContent extends StatelessWidget {
         slivers: [
           CupertinoSliverNavigationBar(
             largeTitle: Text('Sheet'),
+            trailing: CupertinoButton(
+                padding: EdgeInsets.zero,
+                child: Text(_snapDisabled ? 'Enable Snaps' : 'Disable Snaps'),
+                onPressed: () {
+                  final controller =
+                      StupidSimpleSheetController.maybeOf(context);
+                  controller
+                      ?.overrideSnappingConfig(
+                        _snapDisabled ? null : SheetSnappingConfig.full,
+                        animateToComply: true,
+                      )
+                      ?.ignore();
+                  setState(() {
+                    _snapDisabled = !_snapDisabled;
+                  });
+                }),
             leading: CupertinoButton(
               child: Text("Close"),
               padding: EdgeInsets.zero,

--- a/packages/stupid_simple_sheet/lib/src/snapping_point.dart
+++ b/packages/stupid_simple_sheet/lib/src/snapping_point.dart
@@ -39,6 +39,9 @@ sealed class SheetSnappingConfig {
     double? initialSnap,
   }) = _AbsoluteSnappingConfig;
 
+  /// A snapping configuration that only includes the fully open state (1.0).
+  static const SheetSnappingConfig full = SheetSnappingConfig.relative([1.0]);
+
   /// The raw snapping points as provided to the constructor.
   List<double> get points;
 
@@ -108,9 +111,12 @@ class RelativeSnappingConfig extends SheetSnappingConfig {
   /// velocity.
   double findTargetSnapPoint(
     double currentRelativePosition,
-    double velocity,
-  ) {
-    final allPoints = getAllPoints();
+    double velocity, {
+    bool includeClosed = true,
+  }) {
+    final allPoints = getAllPoints()
+        .where((p) => includeClosed || p > 0) // Exclude 0 if needed
+        .toList();
 
     // For high velocity, predict where the sheet would naturally settle
     const velocityThreshold = 0.5;

--- a/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
@@ -22,7 +22,7 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
     this.clearBarrierImmediately = true,
     this.backgroundColor = CupertinoColors.systemBackground,
     this.callNavigatorUserGestureMethods = false,
-    this.snappingConfig = const SheetSnappingConfig.relative([1.0]),
+    this.snappingConfig = SheetSnappingConfig.full,
   });
 
   @override
@@ -48,7 +48,7 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
   @override
   bool get barrierDismissible => switch (navigator) {
         NavigatorState(:final context) =>
-          snappingConfig.resolveWith(context).hasInbetweenSnaps,
+          effectiveSnappingConfig.resolveWith(context).hasInbetweenSnaps,
         _ => false,
       };
 
@@ -75,8 +75,8 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
           context,
           animation: animation.clamped,
           secondaryAnimation: secondaryAnimation.clamped,
-          slideBackRange: snappingConfig.resolve(height).topTwoPoints,
-          opacityRange: snappingConfig.resolve(height).bottomTwoPoints,
+          slideBackRange: effectiveSnappingConfig.resolve(height).topTwoPoints,
+          opacityRange: effectiveSnappingConfig.resolve(height).bottomTwoPoints,
           child: child,
         );
       };
@@ -105,8 +105,8 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
         context,
         animation: controller!.view,
         secondaryAnimation: secondaryAnimation,
-        slideBackRange: snappingConfig.resolve(height).topTwoPoints,
-        opacityRange: snappingConfig.resolve(height).bottomTwoPoints,
+        slideBackRange: effectiveSnappingConfig.resolve(height).topTwoPoints,
+        opacityRange: effectiveSnappingConfig.resolve(height).bottomTwoPoints,
         backgroundColor: backgroundColor,
         child: child,
       ),


### PR DESCRIPTION


## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
