### PR TITLE
fix: `overrideSnappingConfig` and `animateToRelative` could interrupt sheet dismissal and break Navigator

### DIFF
--- a/packages/stupid_simple_sheet/example/lib/main.dart
+++ b/packages/stupid_simple_sheet/example/lib/main.dart
@@ -187,7 +187,7 @@ class _SnappingSheetContentState extends State<_SnappingSheetContent> {
                         _snapDisabled ? null : SheetSnappingConfig.full,
                         animateToComply: true,
                       )
-                      ?.ignore();
+                      .ignore();
                   setState(() {
                     _snapDisabled = !_snapDisabled;
                   });

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -476,6 +476,9 @@ mixin StupidSimpleSheetController<T> on StupidSimpleSheetTransitionMixin<T> {
       'Controller is null. Make sure the route is pushed before calling.',
     );
 
+    // We only animate if this route is still current
+    if (!isCurrent) return TickerFuture.complete();
+
     final double target;
 
     if (snap) {
@@ -518,7 +521,7 @@ mixin StupidSimpleSheetController<T> on StupidSimpleSheetTransitionMixin<T> {
   /// // Reset to the original configuration
   /// controller.updateSnappingConfig(null);
   /// ```
-  TickerFuture? overrideSnappingConfig(
+  TickerFuture overrideSnappingConfig(
     SheetSnappingConfig? newConfig, {
     bool animateToComply = false,
   }) {
@@ -529,7 +532,8 @@ mixin StupidSimpleSheetController<T> on StupidSimpleSheetTransitionMixin<T> {
 
     _snappingConfigOverride = newConfig;
 
-    if (animateToComply) {
+    // Only animate to comply if requested and if this route is still current
+    if (animateToComply && isCurrent) {
       final currentPosition = controller!.value;
       final config = effectiveSnappingConfig.resolveWith(navigator!.context);
 
@@ -542,7 +546,7 @@ mixin StupidSimpleSheetController<T> on StupidSimpleSheetTransitionMixin<T> {
 
       // If the current position is already at a valid snap point, don't animate
       if ((targetPosition - currentPosition).abs() < 0.001) {
-        return null;
+        return TickerFuture.complete();
       }
 
       final simulation = motion.createSimulation(
@@ -554,6 +558,6 @@ mixin StupidSimpleSheetController<T> on StupidSimpleSheetTransitionMixin<T> {
       return controller!.animateWith(simulation);
     }
 
-    return null;
+    return TickerFuture.complete();
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
