### PR TITLE
feat: improve font loading drastically

### DIFF
--- a/packages/snaptest/README.md
+++ b/packages/snaptest/README.md
@@ -283,10 +283,26 @@ testWidgets('Custom directory example', (tester) async {
 
 The helper scripts will work with any custom directory name you specify.
 
-## Font Limitations ⚠️
+## Font Rendering 🔤
+
+### macOS: SF Pro Fonts (Recommended)
+
+For the most accurate iOS screenshot rendering on macOS, install Apple's SF Pro fonts:
+
+1. Download SF Pro fonts from [Apple's developer site](https://developer.apple.com/fonts/)
+2. Install the fonts to `/Library/Fonts` (system-wide installation)
+3. Restart your terminal/IDE if needed
+
+With SF Pro fonts installed, `loadFontsAndIcons()` will automatically use them for Cupertino widgets, making your screenshots match actual iOS rendering more closely.
+
+**Without SF Pro fonts on macOS**: Snaptest automatically falls back to Roboto fonts for consistency. You'll see a debug message during test runs if the fonts aren't found.
+
+**On other platforms (Linux, Windows)**: Cupertino widgets will always use Roboto fonts as a fallback, since Apple's SF Pro fonts cannot be legally redistributed or used outside of macOS.
+
+### Font Limitations
 
 Due to Flutter's test environment limitations:
-- **iOS system fonts** are replaced with Roboto for consistency
+- **iOS system fonts** use SF Pro (if installed on macOS) or Roboto (fallback)
 - **Google Fonts** only work if bundled as local assets (not fetched remotely)
 - **Custom fonts** must be included in your `pubspec.yaml`
 

--- a/packages/snaptest/lib/snaptest.dart
+++ b/packages/snaptest/lib/snaptest.dart
@@ -4,6 +4,7 @@ library;
 export 'package:device_frame/device_frame.dart' show DeviceInfo, Devices;
 
 export 'src/fake_device.dart' show WidgetTesterDevice;
+export 'src/font_loading.dart' show loadFontsAndIcons;
 export 'src/screenshot_test_function.dart' show snapTest;
-export 'src/snap.dart' show loadFontsAndIcons, setTestViewToFakeDevice, snap;
+export 'src/snap.dart' show setTestViewToFakeDevice, snap;
 export 'src/snaptest_settings.dart' show SnaptestSettings;

--- a/packages/snaptest/lib/src/font_loading.dart
+++ b/packages/snaptest/lib/src/font_loading.dart
@@ -1,0 +1,284 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart';
+import 'package:snaptest/src/flutter_sdk_root.dart';
+import 'package:snaptest/src/snap.dart';
+
+@internal
+const fontFormats = ['.ttf', '.otf', '.ttc'];
+
+bool _fontsLoaded = false;
+
+/// Loads fonts and icons required for consistent screenshot rendering.
+///
+/// This function ensures that all fonts (including system fonts) and icons
+/// are properly loaded before taking screenshots. It should be called once
+/// before running any tests that use [snap] to ensure consistent text
+/// rendering across all screenshots.
+///
+/// **Important**: Once fonts are loaded, they cannot be unloaded due to
+/// Flutter's limitations. This means that if [loadFontsAndIcons] is called
+/// during one test, all subsequent tests in the same test run will use the
+/// loaded fonts, which may cause text to render differently than in a fresh
+/// test environment.
+///
+/// You can work around this limitation by using [snap] with `matchToGolden`
+/// set to `true`, instead of [matchesGoldenFile], which will block out all
+/// text independent of the loaded fonts.
+///
+/// ## What it does
+///
+/// - Loads all application fonts defined in `pubspec.yaml`
+/// - If running on macOS, attempts to load SF Pro fonts for accurate Cupertino
+///   widget rendering. You can download these fonts from Apple's developer
+///   site:
+///   https://developer.apple.com/fonts/
+/// - If SF Pro fonts are not available, falls back to using Roboto fonts
+///   for Cupertino widgets
+/// - Ensures icons are properly loaded for rendering
+///
+/// The function is idempotent - calling it multiple times has no additional
+/// effect after the first call.
+Future<void> loadFontsAndIcons() async {
+  if (_fontsLoaded) return;
+
+  await _loadMaterialFontsFromSdk();
+  await _loadFontsFromFontManifest();
+
+  try {
+    await _loadMacOSFonts();
+  } on MacOsFontLoadException catch (_) {
+    await _overrideCupertinoFonts();
+  }
+
+  _fontsLoaded = true;
+}
+
+/// Loads fonts from the given [fromPaths] into the Flutter engine under the
+/// specified [family].
+Future<void> loadFont(String family, List<String> fromPaths) async {
+  if (fromPaths.isEmpty) {
+    return;
+  }
+
+  await maybeRunAsync(() async {
+    final fontLoader = FontLoader(family);
+    for (final path in fromPaths) {
+      try {
+        final file = File(path);
+        if (file.existsSync()) {
+          final bytes = file.readAsBytesSync();
+          fontLoader.addFont(Future.value(bytes.buffer.asByteData()));
+        } else {
+          final data = rootBundle.load(path);
+          fontLoader.addFont(Future.value(data));
+        }
+      } catch (e, _) {
+        debugPrint("Could not load font $path: $e");
+      }
+    }
+
+    await fontLoader.load();
+  });
+}
+
+Future<void> _loadMaterialFontsFromSdk() async {
+  final root = flutterSdkRoot().absolute.path;
+
+  final materialFontsDir = Directory(
+    '$root/bin/cache/artifacts/material_fonts/',
+  );
+
+  final files = materialFontsDir.listSync().whereType<File>().toList();
+
+  final robotoFonts = files
+      .where((file) => file.isRobotoFont)
+      .map((file) => file.path)
+      .toList();
+
+  await loadFont('Roboto', robotoFonts);
+
+  final robotoCondensedFonts = files
+      .where((file) => file.isRobotoCondensedFont)
+      .map((file) => file.path)
+      .toList();
+  await loadFont('RobotoCondensed', robotoCondensedFonts);
+
+  final materialIcons = files
+      .where((file) => file.isMaterialIconsFont)
+      .map((file) => file.path)
+      .toList();
+  await loadFont('MaterialIcons', materialIcons);
+}
+
+Future<void> _loadFontsFromFontManifest() async {
+  final fontManifestContent = await maybeRunAsync(
+    () => rootBundle.loadString('FontManifest.json'),
+  );
+
+  if (fontManifestContent == null || fontManifestContent.isEmpty) {
+    return;
+  }
+
+  final fontManifestEntries = _parseFontManifest(fontManifestContent);
+
+  for (final (family, assets) in fontManifestEntries) {
+    final packageAsset = assets
+        .where((it) => it.startsWith('packages/'))
+        .firstOrNull;
+    final packageName = packageAsset?.split('/')[1];
+
+    if (packageName == null) {
+      await loadFont(family, assets);
+    } else {
+      final fontFamilyName = family.split('/').last;
+      // We load it both ways to cover both possibilities.
+      await loadFont(fontFamilyName, assets);
+      await loadFont('packages/$packageName/$fontFamilyName', assets);
+    }
+  }
+}
+
+List<(String, List<String>)> _parseFontManifest(String content) {
+  final fonts = <(String, List<String>)>[];
+  final json = jsonDecode(content) as List<dynamic>;
+  for (final item in json) {
+    if (item is! Map<String, dynamic>) {
+      continue;
+    }
+    final family = item['family'] as String;
+    final assets = (item['fonts'] as List<dynamic>)
+        .cast<Map<String, dynamic>>()
+        .map((font) => font['asset'] as String)
+        .toList();
+    fonts.add((family, assets));
+  }
+  return fonts;
+}
+
+Future<void> _overrideCupertinoFonts() async {
+  final root = flutterSdkRoot().absolute.path;
+
+  final materialFontsDir = Directory(
+    '$root/bin/cache/artifacts/material_fonts/',
+  );
+
+  final existingFonts = materialFontsDir
+      .listSync()
+      .whereType<File>()
+      .where(
+        (font) => fontFormats.any((element) => font.path.endsWith(element)),
+      )
+      .toList();
+
+  final robotoFonts = existingFonts
+      .where((font) {
+        final name = basename(font.path).toLowerCase();
+        return name.startsWith('Roboto-'.toLowerCase());
+      })
+      .map((file) => file.path)
+      .toList();
+  if (robotoFonts.isEmpty) {
+    debugPrint("Warning: No Roboto font found in SDK");
+  }
+  await loadFont('CupertinoSystemText', robotoFonts);
+  await loadFont('CupertinoSystemDisplay', robotoFonts);
+}
+
+Future<void> _loadMacOSFonts() async {
+  if (!Platform.isMacOS) {
+    throw MacOsFontLoadException(
+      '_loadMacOSFonts called on non-macOS platform',
+    );
+  }
+
+  final base = Directory('/Library/Fonts');
+
+  final sfProTextFonts = base
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.isSFProTextFont)
+      .map((file) => file.path)
+      .toList();
+
+  final sfProDisplayFonts = base
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.isSFProDisplayFont)
+      .map((file) => file.path)
+      .toList();
+
+  if (sfProTextFonts.isEmpty || sfProDisplayFonts.isEmpty) {
+    debugPrint(
+      "You are on macOS but no SF Pro fonts were found in "
+      "/Library/Fonts. Please install them from Apple's developer site: https://developer.apple.com/fonts/",
+    );
+
+    throw MacOsFontLoadException('SF Pro fonts not found on macOS');
+  }
+
+  await loadFont('CupertinoSystemText', sfProTextFonts);
+  await loadFont('CupertinoSystemDisplay', sfProDisplayFonts);
+}
+
+extension on File {
+  bool get isFont {
+    final lower = path.toLowerCase();
+    return fontFormats.any(lower.endsWith);
+  }
+
+  bool get isRobotoFont {
+    if (!isFont) {
+      return false;
+    }
+    final name = basename(path).toLowerCase();
+    return name.startsWith('roboto-');
+  }
+
+  bool get isRobotoCondensedFont {
+    if (!isFont) {
+      return false;
+    }
+    final name = basename(path).toLowerCase();
+    return name.startsWith('robotocondensed-');
+  }
+
+  bool get isMaterialIconsFont {
+    if (!isFont) {
+      return false;
+    }
+    final name = basename(path).toLowerCase();
+    return name.startsWith('materialicons-');
+  }
+
+  bool get isSFProTextFont {
+    if (!isFont) {
+      return false;
+    }
+    final name = basename(path).toLowerCase();
+    return name.startsWith('sf-pro-text');
+  }
+
+  bool get isSFProDisplayFont {
+    if (!isFont) {
+      return false;
+    }
+    final name = basename(path).toLowerCase();
+    return name.startsWith('sf-pro-display');
+  }
+}
+
+@internal
+class MacOsFontLoadException implements Exception {
+  MacOsFontLoadException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'CupertinoFontLoadException: $message';
+}

--- a/packages/snaptest/lib/src/snap.dart
+++ b/packages/snaptest/lib/src/snap.dart
@@ -10,9 +10,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart';
 import 'package:snaptest/src/blocked_text_painting_context.dart';
 import 'package:snaptest/src/fake_device.dart';
-import 'package:snaptest/src/flutter_sdk_root.dart';
+import 'package:snaptest/src/font_loading.dart';
 import 'package:snaptest/src/snaptest_settings.dart';
-import 'package:spot/spot.dart';
 // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart';
 
@@ -323,58 +322,6 @@ Future<ui.Image?> takeDeviceScreenshot({
   return image;
 }
 
-bool _fontsLoaded = false;
-
-/// Loads fonts and icons required for consistent screenshot rendering.
-///
-/// This function ensures that all fonts (including system fonts) and icons
-/// are properly loaded before taking screenshots. It should be called once
-/// before running any tests that use [snap] to ensure consistent text
-/// rendering across all screenshots.
-///
-/// **Important**: Once fonts are loaded, they cannot be unloaded due to
-/// Flutter's limitations. This means that if [loadFontsAndIcons] is called
-/// during one test, all subsequent tests in the same test run will use the
-/// loaded fonts, which may cause text to render differently than in a fresh
-/// test environment.
-///
-/// ## Recommended Usage
-///
-/// Add this to your `flutter_test_config.dart` file to ensure fonts are
-/// loaded before all tests:
-///
-/// ```dart
-/// import 'dart:async';
-/// import 'package:snaptest/snaptest.dart';
-///
-/// Future<void> testExecutable(FutureOr<void> Function() testMain) async {
-///   await loadFontsAndIcons();
-///   await testMain();
-/// }
-/// ```
-///
-/// This prevents side effects where [snap] calls might produce different
-/// results depending on whether fonts were loaded in previous tests.
-///
-/// ## What it does
-///
-/// - Loads all application fonts defined in `pubspec.yaml`
-/// - Overrides Cupertino system fonts with Roboto for consistency, since
-/// Cupertino fonts can't be loaded on all platforms
-/// - Ensures icons are properly loaded for rendering
-/// - Sets a flag to prevent duplicate loading in the same test session
-///
-/// The function is idempotent - calling it multiple times has no additional
-/// effect after the first call.
-Future<void> loadFontsAndIcons() async {
-  if (_fontsLoaded) return;
-
-  await loadAppFonts();
-  await _overrideCupertinoFonts();
-
-  _fontsLoaded = true;
-}
-
 Future<VoidCallback> _setUpForSettings(SnaptestSettings settings) async {
   final restoreImages = TestWidgetsFlutterBinding.instance.imageCache.clear;
 
@@ -394,37 +341,6 @@ Future<VoidCallback> _setUpForSettings(SnaptestSettings settings) async {
     debugDisableShadows = previousShadows;
     restoreImages();
   };
-}
-
-Future<void> _overrideCupertinoFonts() async {
-  final root = flutterSdkRoot().absolute.path;
-
-  final materialFontsDir = Directory(
-    '$root/bin/cache/artifacts/material_fonts/',
-  );
-
-  final fontFormats = ['.ttf', '.otf', '.ttc'];
-  final existingFonts = materialFontsDir
-      .listSync()
-      // dartfmt come on,...
-      .whereType<File>()
-      .where(
-        (font) => fontFormats.any((element) => font.path.endsWith(element)),
-      )
-      .toList();
-
-  final robotoFonts = existingFonts
-      .where((font) {
-        final name = basename(font.path).toLowerCase();
-        return name.startsWith('Roboto-'.toLowerCase());
-      })
-      .map((file) => file.path)
-      .toList();
-  if (robotoFonts.isEmpty) {
-    debugPrint("Warning: No Roboto font found in SDK");
-  }
-  await loadFont('CupertinoSystemText', robotoFonts);
-  await loadFont('CupertinoSystemDisplay', robotoFonts);
 }
 
 /// Pre-caches all images so that they will be rendered correctly when taking

--- a/packages/snaptest/pubspec.yaml
+++ b/packages/snaptest/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
     sdk: flutter
   meta: ">=1.15.0 <2.0.0"
   path: ">=1.0.0 <2.0.0"
-  spot: ">=0.18.0 <1.0.0"
   test_api: ">=0.5.0 <0.8.0"
 
 executables:

--- a/packages/snaptest/test/snapper_test.dart
+++ b/packages/snaptest/test/snapper_test.dart
@@ -197,6 +197,25 @@ void main() {
           expect(files.first.path, isNot(contains('landscape')));
         },
       );
+
+      testWidgets('works from within runAsync', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: Text('Async Snap Test'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.runAsync(() async {
+          final files = await snap(name: 'run_async_snap');
+
+          expect(files, hasLength(1));
+          expect(files.first.existsSync(), isTrue);
+        });
+      });
     });
 
     group('SnaptestSettings', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ melos:
       workspaceChangelog: false
       changelogCommitBodies:
         include: true
-        onlyBreaking: true
+        onlyBreaking: false
       hooks:
         preCommit: |
           melos run generate


### PR DESCRIPTION
- Remove dependency on spot package
- Load actual SFPro fonts on macOS if you have them installed, otherwise print a warning and fall back to Roboto.
- Allow calling `snap()` from within `runAsync`, even with font loading.

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
