### PR TITLE
feat: add `originateAboveBottomViewInset` to `StupidSimpleSheet` and …

### DIFF
--- a/packages/stupid_simple_sheet/example/lib/main.dart
+++ b/packages/stupid_simple_sheet/example/lib/main.dart
@@ -52,6 +52,7 @@ final stupidSimpleSheetRoutes = [
           StupidSimpleSheetRoute<T>(
         settings: page,
         motion: CupertinoMotion.smooth(),
+        originateAboveBottomViewInset: true,
         child: child,
       ),
     ),
@@ -159,6 +160,11 @@ class _CupertinoSheetContent extends StatelessWidget {
           ),
           SliverSafeArea(
               sliver: SliverMainAxisGroup(slivers: [
+            SliverToBoxAdapter(
+              child: CupertinoTextField(
+                placeholder: 'Type something...',
+              ),
+            ),
             SliverList(
               delegate: SliverChildBuilderDelegate(
                 (context, index) => CupertinoListTile(
@@ -323,6 +329,7 @@ class _SmallSheetContent extends StatefulWidget {
 
 class _SmallSheetContentState extends State<_SmallSheetContent> {
   int _itemCount = 5;
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -345,6 +352,10 @@ class _SmallSheetContentState extends State<_SmallSheetContent> {
                   curve: CupertinoMotion.smooth().toCurve,
                   child: Column(
                     children: [
+                      CupertinoTextField(
+                        autofocus: true,
+                        placeholder: 'Type something...',
+                      ),
                       for (var i = 0; i < _itemCount; i++)
                         CupertinoListTile(
                           title: Text('Item #${i + 1}'),

--- a/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
@@ -24,6 +24,7 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
     this.callNavigatorUserGestureMethods = false,
     this.snappingConfig = SheetSnappingConfig.full,
     this.draggable = true,
+    this.originateAboveBottomViewInset = false,
   });
 
   @override
@@ -70,6 +71,9 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
 
   @override
   final bool draggable;
+
+  @override
+  final bool originateAboveBottomViewInset;
 
   @override
   DelegatedTransitionBuilder? get delegatedTransition =>


### PR DESCRIPTION
…its mixin

The cupertino sheet does not support this, as it always takes full height anyway, and should continue handling safe areas internally

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
