### PR TITLE
fix: don't interfere with `pop()` animation while sheet is being dragged

### DIFF
--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -400,11 +400,12 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
     BuildContext context,
   ) {
     if (callNavigatorUserGestureMethods) {
-      Navigator.of(context).didStartUserGesture();
+      navigator?.didStartUserGesture();
     }
   }
 
   void _handleDragUpdate(BuildContext context, double delta, bool wouldScroll) {
+    if (_poppedNotifier.value) return;
     final currentValue = controller?.value ?? 0;
     var adjustedDelta = delta;
 
@@ -442,8 +443,11 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
   ) {
     final currentValue = controller!.value;
     if (callNavigatorUserGestureMethods) {
-      Navigator.of(context).didStopUserGesture();
+      navigator?.didStopUserGesture();
     }
+
+    // If the route has been popped, don't interfere with the closing animation
+    if (_poppedNotifier.value) return;
 
     _dragEndVelocity = velocity;
 
@@ -477,7 +481,7 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
 
       // If target is 0 (closed), dismiss the sheet
       if (targetValue <= 0.001) {
-        Navigator.of(context).pop();
+        navigator?.pop();
       } else {
         // Animate to the target snap point
         final snapSim = motion.createSimulation(

--- a/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
+++ b/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
@@ -288,6 +288,33 @@ void main() {
       await gesture.up();
     });
 
+    testWidgets('can be closed properly while dragging', (tester) async {
+      await tester.pumpWidget(build());
+      await tester.tap(find.byKey(const ValueKey('button')));
+      await tester.pumpAndSettle();
+      final scaffoldFinder = find.byKey(const ValueKey('scaffold'));
+
+      final gesture =
+          await tester.startGesture(tester.getCenter(scaffoldFinder));
+
+      const dragFrames = 10;
+      const dragPx = 30.0;
+
+      for (var i = 0; i < dragFrames; i++) {
+        await gesture.moveBy(const Offset(0, dragPx));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // Now close while dragging
+      Navigator.of(tester.element(scaffoldFinder)).pop();
+
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('scaffold')), findsNothing);
+
+      await gesture.up();
+    });
+
     group('originateAboveBottomViewInset', () {
       const keyboardHeight = 300.0;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
