### PR TITLE
fix: dragging up from a snap point performes one frame of scroll before transitioning to dragging

### DIFF
--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -170,7 +170,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   var _scrollStartedAtTop = false;
 
   DragStartDetails? _dragStartDetails;
-  late ScrollMetrics _startMetrics;
+  ScrollMetrics? _startMetrics;
 
   bool get hasVertical =>
       widget.onVerticalDragStart != null ||
@@ -246,7 +246,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
           valueListenable: _isDragging,
           builder: (context, value, child) {
             return ScrollConfiguration(
-              behavior: value
+              behavior: value || widget.scrollableCanMoveBack
                   ? _DraggingScrollBehavior(
                       parent: ScrollConfiguration.of(context),
                       axes: dragAxes,
@@ -413,7 +413,7 @@ class _DraggingScrollBehavior extends ScrollBehavior {
     required this.axes,
   });
 
-  final ScrollMetrics startMetrics;
+  final ScrollMetrics? startMetrics;
 
   final ScrollBehavior parent;
 
@@ -493,7 +493,7 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
 
   final Set<Axis> axes;
 
-  final ScrollMetrics startMetrics;
+  final ScrollMetrics? startMetrics;
 
   @override
   _OverscrollScrollPhysics applyTo(ScrollPhysics? ancestor) {

--- a/packages/stupid_simple_sheet/example/lib/main.dart
+++ b/packages/stupid_simple_sheet/example/lib/main.dart
@@ -54,6 +54,8 @@ final stupidSimpleSheetRoutes = [
         motion: CupertinoMotion.smooth(),
         originateAboveBottomViewInset: true,
         child: child,
+        backgroundColor: Colors.transparent,
+        clipBehavior: Clip.none,
       ),
     ),
   ),

--- a/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
+++ b/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
@@ -514,6 +514,46 @@ void main() {
       });
     });
 
+    group('snap and scroll', () {
+      testWidgets('will not scroll at all when dragged up from snap',
+          (tester) async {
+        await tester.pumpWidget(
+          build(
+            snappingConfig: const SheetSnappingConfig.relative(
+              [0.5, 1.0],
+            ),
+          ),
+        );
+
+        await tester.tap(find.byKey(const ValueKey('button')));
+        await tester.pumpAndSettle();
+
+        final scrollableFinder = find.descendant(
+          of: find.byKey(const ValueKey('scaffold')),
+          matching: find.byType(Scrollable),
+        );
+
+        expect(scrollableFinder, findsOneWidget);
+        expect(
+          tester.state<ScrollableState>(scrollableFinder).position.pixels,
+          equals(0.0),
+        );
+
+        // Drag sheet to top quickly
+        final gesture =
+            await tester.startGesture(tester.getTopLeft(scrollableFinder));
+        for (var i = 0; i < 15; i++) {
+          await gesture.moveBy(const Offset(0, -20));
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+
+        expect(
+          tester.state<ScrollableState>(scrollableFinder).position.pixels,
+          equals(0.0),
+        );
+      });
+    });
+
     group('controlling imperatively', () {
       testWidgets('can find controller', (tester) async {
         final widget = build();


### PR DESCRIPTION
…

## Description

<!--- Describe your changes in detail -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ ] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
