### PR TITLE
feat: add ignoreWhileKeyboard (defaults to true) to DragDismissable

### DIFF
--- a/packages/heroine/analysis_options.yaml
+++ b/packages/heroine/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lintervention/analysis_options.yaml
+
+formatter:
+  page_width: 80
+  trailing_commas: preserve

--- a/packages/heroine/lib/src/drag_dismissable.dart
+++ b/packages/heroine/lib/src/drag_dismissable.dart
@@ -106,16 +106,20 @@ class _DragDismissableState extends State<DragDismissable> {
   Offset _offset = Offset.zero;
   Velocity _velocity = Velocity.zero;
 
-  VoidCallback? get onDismiss => widget.onDismiss ?? (widget._popAsDismiss ? () => Navigator.maybePop(context) : null);
+  VoidCallback? get onDismiss =>
+      widget.onDismiss ??
+      (widget._popAsDismiss ? () => Navigator.maybePop(context) : null);
 
-  double get progress => switch ((widget.axisAffinity, widget.constrainToAxis)) {
+  double get progress =>
+      switch ((widget.axisAffinity, widget.constrainToAxis)) {
         (null, _) || (_, false) => _offset.distance / widget.threshold,
         (Axis.horizontal, true) => _offset.dx.abs() / widget.threshold,
         (Axis.vertical, true) => _offset.dy.abs() / widget.threshold,
       }
           .clamp(0, 1);
 
-  double dismissVelocity(Velocity velocity) => switch ((widget.axisAffinity, widget.constrainToAxis)) {
+  double dismissVelocity(Velocity velocity) =>
+      switch ((widget.axisAffinity, widget.constrainToAxis)) {
         (null, _) || (_, false) => velocity.pixelsPerSecond.distance,
         (Axis.horizontal, true) => velocity.pixelsPerSecond.dx.abs(),
         (Axis.vertical, true) => velocity.pixelsPerSecond.dy.abs(),
@@ -132,21 +136,62 @@ class _DragDismissableState extends State<DragDismissable> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onPanStart: widget.axisAffinity == null && !widget._disabled && _canDismiss() ? _start : null,
-      onPanUpdate: widget.axisAffinity == null && !widget._disabled && _canDismiss() ? _update : null,
-      onPanCancel: widget.axisAffinity == null && !widget._disabled && _canDismiss() ? _cancel : null,
-      onPanEnd: widget.axisAffinity == null && !widget._disabled && _canDismiss() ? _end : null,
-      onVerticalDragStart: widget.axisAffinity == Axis.vertical && !widget._disabled && _canDismiss() ? _start : null,
-      onVerticalDragUpdate: widget.axisAffinity == Axis.vertical && !widget._disabled && _canDismiss() ? _update : null,
-      onVerticalDragCancel: widget.axisAffinity == Axis.vertical && !widget._disabled && _canDismiss() ? _cancel : null,
-      onVerticalDragEnd: widget.axisAffinity == Axis.vertical && !widget._disabled && _canDismiss() ? _end : null,
-      onHorizontalDragStart:
-          widget.axisAffinity == Axis.horizontal && !widget._disabled && _canDismiss() ? _start : null,
-      onHorizontalDragUpdate:
-          widget.axisAffinity == Axis.horizontal && !widget._disabled && _canDismiss() ? _update : null,
-      onHorizontalDragCancel:
-          widget.axisAffinity == Axis.horizontal && !widget._disabled && _canDismiss() ? _cancel : null,
-      onHorizontalDragEnd: widget.axisAffinity == Axis.horizontal && !widget._disabled && _canDismiss() ? _end : null,
+      onPanStart:
+          widget.axisAffinity == null && !widget._disabled && _canDismiss()
+              ? _start
+              : null,
+      onPanUpdate:
+          widget.axisAffinity == null && !widget._disabled && _canDismiss()
+              ? _update
+              : null,
+      onPanCancel:
+          widget.axisAffinity == null && !widget._disabled && _canDismiss()
+              ? _cancel
+              : null,
+      onPanEnd:
+          widget.axisAffinity == null && !widget._disabled && _canDismiss()
+              ? _end
+              : null,
+      onVerticalDragStart: widget.axisAffinity == Axis.vertical &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _start
+          : null,
+      onVerticalDragUpdate: widget.axisAffinity == Axis.vertical &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _update
+          : null,
+      onVerticalDragCancel: widget.axisAffinity == Axis.vertical &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _cancel
+          : null,
+      onVerticalDragEnd: widget.axisAffinity == Axis.vertical &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _end
+          : null,
+      onHorizontalDragStart: widget.axisAffinity == Axis.horizontal &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _start
+          : null,
+      onHorizontalDragUpdate: widget.axisAffinity == Axis.horizontal &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _update
+          : null,
+      onHorizontalDragCancel: widget.axisAffinity == Axis.horizontal &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _cancel
+          : null,
+      onHorizontalDragEnd: widget.axisAffinity == Axis.horizontal &&
+              !widget._disabled &&
+              _canDismiss()
+          ? _end
+          : null,
       child: MotionBuilder(
         active: _dragStartOffset == null,
         motion: widget.motion,
@@ -201,7 +246,9 @@ class _DragDismissableState extends State<DragDismissable> {
   }
 
   void _end(DragEndDetails details) {
-    if (ModalRoute.of(context)?.popDisposition == RoutePopDisposition.doNotPop && widget._popAsDismiss) {
+    if (ModalRoute.of(context)?.popDisposition ==
+            RoutePopDisposition.doNotPop &&
+        widget._popAsDismiss) {
       _cancel();
 
       return;


### PR DESCRIPTION
## Description

This PR introduces the ignoreWhileKeyboard property to the DragDismissable widget.

When enabled, it prevents the dismiss gesture from triggering if the software keyboard is visible. This is particularly useful for preventing accidental dismissals while the user is typing in a text field within the dismissable view.

**Changes**
Added `ignoreWhileKeyboard` parameter (defaults to `true`).

Implemented `_canDismiss` check using `MediaQuery.viewInsetsOf(context)`.

Updated all gestures on the GestureDetector to respect the keyboard state.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
