### PR TITLE
feat: add snap.pixel()

### DIFF
--- a/packages/snaptest/README.md
+++ b/packages/snaptest/README.md
@@ -128,6 +128,37 @@ testWidgets('Get image', (tester) async {
 });
 ```
 
+## Getting a single pixel color
+
+Use `snap.pixel()` to read one rendered pixel as a `Color`. The offset uses the
+same Flutter logical coordinate space as `tester.getRect(...)` and `crop`:
+
+```dart
+testWidgets('Get pixel color', (tester) async {
+  const key = Key('status-dot');
+
+  await tester.pumpWidget(
+    const MaterialApp(
+      home: Center(
+        child: SizedBox(
+          key: key,
+          width: 20,
+          height: 20,
+          child: ColoredBox(color: Colors.green),
+        ),
+      ),
+    ),
+  );
+
+  final color = await snap.pixel(tester.getCenter(find.byKey(key)));
+
+  expect(color, equals(Colors.green));
+});
+```
+
+`from`, `crop`, `settings`, `device`, and `orientation` work the same way they
+do for the other snap methods.
+
 ## All the Options
 
 ### Multiple screenshots per test

--- a/packages/snaptest/lib/src/snap.dart
+++ b/packages/snaptest/lib/src/snap.dart
@@ -344,6 +344,47 @@ class Snap {
     restore();
     return result;
   }
+
+  /// Returns the color of a single pixel in the snapped image.
+  ///
+  /// The [offset] is in the same Flutter logical coordinate space as [crop].
+  ///
+  /// ```dart
+  /// final color = await snap.pixel(tester.getCenter(find.byKey(key)));
+  /// expect(color, equals(Colors.red));
+  /// ```
+  ///
+  /// {@macro snaptest_from_and_crop}
+  Future<Color> pixel(
+    Offset offset, {
+    Finder? from,
+    Rect? crop,
+    SnaptestSettings? settings,
+    DeviceInfo? device,
+    Orientation? orientation,
+  }) async {
+    final s = settings ?? SnaptestSettings.global;
+    final resolvedDevice = device ?? activeDeviceVariant?.$1;
+    final resolvedOrientation =
+        orientation ?? activeDeviceVariant?.$2 ?? Orientation.portrait;
+
+    final restore = await _setUpForSettings(
+      settings: s,
+      from: from,
+    );
+
+    final color = await _takeDeviceScreenshotPixel(
+      offset: offset,
+      device: resolvedDevice,
+      orientation: resolvedOrientation,
+      from: from,
+      crop: crop,
+      settings: s,
+    );
+
+    restore();
+    return color;
+  }
 }
 
 /// Resolves name, device, orientation, and builds the filename.
@@ -578,6 +619,104 @@ Future<ui.Image?> _takeDeviceScreenshot({
   );
 
   return image;
+}
+
+Future<Color> _takeDeviceScreenshotPixel({
+  required Offset offset,
+  required DeviceInfo? device,
+  required SnaptestSettings settings,
+  required Orientation orientation,
+  Finder? from,
+  Rect? crop,
+}) async {
+  final finder = from ?? find.byType(View);
+
+  final pixel = await _runInFakeDevice(
+    device,
+    orientation,
+    () async {
+      await TestWidgetsFlutterBinding.instance.pump(Duration.zero);
+
+      final captured = await _captureImage(
+        finder.evaluate().single,
+        blockText: settings.blockText,
+        device: device,
+        orientation: orientation,
+        includeDeviceFrame: settings.includeDeviceFrame,
+      );
+
+      try {
+        final color = await _samplePixel(captured, offset, crop: crop);
+        return _PixelSample.color(color);
+      } catch (error, stackTrace) {
+        return _PixelSample.error(error, stackTrace);
+      } finally {
+        captured.image.dispose();
+      }
+    },
+  );
+
+  if (pixel == null) {
+    throw Exception('Could not sample pixel.');
+  }
+
+  if (pixel.error case final error?) {
+    Error.throwWithStackTrace(error, pixel.stackTrace!);
+  }
+
+  return pixel.color!;
+}
+
+Future<Color> _samplePixel(
+  _CapturedImage captured,
+  Offset offset, {
+  Rect? crop,
+}) async {
+  final bounds = captured.logicalBounds;
+  final sampledBounds = crop == null ? bounds : crop.intersect(bounds);
+  if (sampledBounds.isEmpty) {
+    throw ArgumentError.value(
+      crop,
+      'crop',
+      'Crop rect must intersect the snapped bounds.',
+    );
+  }
+
+  if (!sampledBounds.contains(offset)) {
+    throw ArgumentError.value(
+      offset,
+      'offset',
+      'Pixel offset must be inside the snapped bounds.',
+    );
+  }
+
+  final scaleX = captured.imageContentBounds.width / bounds.width;
+  final scaleY = captured.imageContentBounds.height / bounds.height;
+  final sourceX =
+      captured.imageContentBounds.left + (offset.dx - bounds.left) * scaleX;
+  final sourceY =
+      captured.imageContentBounds.top + (offset.dy - bounds.top) * scaleY;
+
+  return _readImagePixel(
+    captured.image,
+    sourceX.floor(),
+    sourceY.floor(),
+  );
+}
+
+Future<Color> _readImagePixel(ui.Image image, int x, int y) async {
+  final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  if (byteData == null) {
+    throw Exception('Could not read screenshot pixels.');
+  }
+
+  final pixelOffset = (y * image.width + x) * 4;
+  return Color.fromARGB(
+    byteData.getUint8(pixelOffset + 3),
+    byteData.getUint8(pixelOffset),
+    byteData.getUint8(pixelOffset + 1),
+    byteData.getUint8(pixelOffset + 2),
+  );
 }
 
 Future<VoidCallback> _setUpForSettings({
@@ -853,6 +992,17 @@ class _CapturedImage {
   final ui.Image image;
   final Rect logicalBounds;
   final Rect imageContentBounds;
+}
+
+class _PixelSample {
+  const _PixelSample.color(Color this.color) : error = null, stackTrace = null;
+
+  const _PixelSample.error(Object this.error, StackTrace this.stackTrace)
+    : color = null;
+
+  final Color? color;
+  final Object? error;
+  final StackTrace? stackTrace;
 }
 
 class _FramedImage {

--- a/packages/snaptest/lib/src/snap.dart
+++ b/packages/snaptest/lib/src/snap.dart
@@ -705,7 +705,7 @@ Future<Color> _samplePixel(
 }
 
 Future<Color> _readImagePixel(ui.Image image, int x, int y) async {
-  final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  final byteData = await image.toByteData();
   if (byteData == null) {
     throw Exception('Could not read screenshot pixels.');
   }

--- a/packages/snaptest/test/snapper_test.dart
+++ b/packages/snaptest/test/snapper_test.dart
@@ -616,6 +616,94 @@ void main() {
       });
     });
 
+    group('snap pixel', () {
+      testWidgets('returns the color at a logical offset', (tester) async {
+        const boxKey = Key('pixel-box');
+        const color = Color.fromARGB(255, 10, 20, 30);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                key: boxKey,
+                width: 50,
+                height: 50,
+                child: ColoredBox(color: color),
+              ),
+            ),
+          ),
+        );
+
+        final sampled = await snap.pixel(
+          tester.getCenter(find.byKey(boxKey)),
+          settings: const SnaptestSettings(blockText: true),
+        );
+
+        expect(sampled, isSameColorAs(color));
+      });
+
+      testWidgets('samples cropped images using logical coordinates', (
+        tester,
+      ) async {
+        const boxKey = Key('cropped-pixel-box');
+        const color = Color.fromARGB(255, 1, 2, 3);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Stack(
+              children: [
+                Positioned.fill(
+                  child: ColoredBox(color: Color.fromARGB(255, 4, 5, 6)),
+                ),
+                Positioned(
+                  left: 40,
+                  top: 60,
+                  child: SizedBox(
+                    key: boxKey,
+                    width: 80,
+                    height: 60,
+                    child: ColoredBox(color: color),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final boxFinder = find.byKey(boxKey);
+        final sampled = await snap.pixel(
+          tester.getCenter(boxFinder),
+          crop: tester.getRect(boxFinder),
+          settings: const SnaptestSettings(blockText: true),
+        );
+
+        expect(sampled, isSameColorAs(color));
+      });
+
+      testWidgets('throws when the logical offset is outside the image', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: SizedBox(
+              width: 20,
+              height: 20,
+              child: ColoredBox(color: Colors.red),
+            ),
+          ),
+        );
+
+        await expectLater(
+          snap.pixel(
+            const Offset(1000, 1000),
+            settings: const SnaptestSettings(blockText: true),
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
     group('snap crop', () {
       testWidgets('crops from the root view so foreground is included', (
         tester,


### PR DESCRIPTION
## Description

Adds `snap.pixel(...)` to snaptest so widget tests can sample a single rendered pixel color using the same capture pipeline and options as the other snap helpers.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes

Made with [Cursor](https://cursor.com)