### PR TITLE
fix: Overlay removed more than once

### DIFF
--- a/packages/motor/lib/src/widgets/motion_draggable.dart
+++ b/packages/motor/lib/src/widgets/motion_draggable.dart
@@ -379,6 +379,7 @@ class _MotionDraggableState<T extends Object> extends State<MotionDraggable<T>>
   void _cancelReturn() {
     if (currentEntry?.mounted ?? false) {
       currentEntry?.remove();
+      currentEntry = null;
     }
     controller.stop(canceled: true);
     isReturning = false;


### PR DESCRIPTION
## Description
In the Motor package for MotionDraggable:
The `if (currentEntry?.mounted ?? false)` check can still pass even though overlay has been removed with `.remove()` which can cause an exception: #278 

Added `currentEntry = null;` so that the check results to false.

Should resolve issue #278 

## Checklist

- [ x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)

