### PR TITLE
feat(fixed_ticker): synchronize shared tick rates

### DIFF
--- a/packages/fixed_ticker/CHANGELOG.md
+++ b/packages/fixed_ticker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: synchronize equal and harmonic fixed ticker rates through a shared scheduler by default, with per-ticker and provider opt-out controls.
+
 ## 0.1.0
 
  - **FEAT**: initial release of `FixedTicker`, fixed ticker provider mixins, `TickerRateScope`, and fixed ticker testing utilities.

--- a/packages/fixed_ticker/README.md
+++ b/packages/fixed_ticker/README.md
@@ -22,6 +22,7 @@ Sometimes that is more work than the animation needs. A background shimmer, deco
 - Drop-in ticker provider mixins for `AnimationController`
 - Fixed rates from frames-per-second values or explicit intervals
 - Seamless switching between fixed-rate and normal vsync ticking
+- Shared, phase-aligned fixed-rate ticks by default
 - `TickerRateScope` for subtree-wide rate control
 - Testing utilities for fixed-rate animations
 
@@ -149,6 +150,28 @@ class _MyState extends State<MyWidget>
 }
 ```
 
+Fixed-rate tickers share scheduling by default, including tickers created by
+different providers. Tickers at the same rate request frames together instead
+of maintaining separate timer phases. Rates with intervals that are exact
+multiples also align: for example, a 10 fps ticker fires alongside every second
+tick of a 20 fps ticker.
+
+Override `shareTicks` when a provider needs independent timing:
+
+```dart
+class _MyState extends State<MyWidget>
+    with SingleFixedTickerProviderStateMixin {
+  @override
+  TickerRate get tickerRate => TickerRate.fps(30);
+
+  @override
+  bool get shareTicks => false;
+}
+```
+
+Like `tickerRate`, a state-driven `shareTicks` value is applied by calling
+`updateTickerRate()`.
+
 ### Using FixedTicker directly
 
 You can also create a `FixedTicker` yourself if you're not using the mixins:
@@ -157,6 +180,7 @@ You can also create a `FixedTicker` yourself if you're not using the mixins:
 final ticker = FixedTicker(
   (elapsed) => print('Elapsed: $elapsed'),
   interval: const Duration(milliseconds: 50), // 20fps
+  shared: false, // Optional: use an independent timer and phase.
 );
 ticker.start();
 // ...later...
@@ -187,7 +211,12 @@ testWidgets('my animation completes', (tester) async {
 
 ## How it works
 
-`FixedTicker` extends Flutter's `Ticker` and overrides `scheduleTick` / `unscheduleTick` to use `Timer.periodic` as a rate limiter when an `interval` is set. When `interval` is `null`, it delegates entirely to the parent and behaves like a normal `Ticker`.
+`FixedTicker` extends Flutter's `Ticker` and overrides `scheduleTick` /
+`unscheduleTick` to use a shared `Timer.periodic` scheduler as a rate limiter
+when an `interval` is set. Compatible intervals share the fastest interval as
+a base and use integer tick generations to align slower rates. Setting
+`shared: false` uses a dedicated periodic timer instead. When `interval` is
+`null`, it delegates entirely to the parent and behaves like a normal `Ticker`.
 
 In fixed-rate mode, the periodic timer does not compute elapsed time itself. Each timer tick schedules a frame callback through the parent `Ticker`, and the parent computes elapsed from Flutter's monotonic frame timestamp. This means:
 

--- a/packages/fixed_ticker/README.md
+++ b/packages/fixed_ticker/README.md
@@ -154,7 +154,9 @@ Fixed-rate tickers share scheduling by default, including tickers created by
 different providers. Tickers at the same rate request frames together instead
 of maintaining separate timer phases. Rates with intervals that are exact
 multiples also align: for example, a 10 fps ticker fires alongside every second
-tick of a 20 fps ticker.
+tick of a 20 fps ticker. The scheduler allows the sub-microsecond rounding
+difference introduced when FPS values are converted to `Duration`s, so common
+pairs such as 30 fps and 15 fps align as expected.
 
 Override `shareTicks` when a provider needs independent timing:
 

--- a/packages/fixed_ticker/example/lib/main.dart
+++ b/packages/fixed_ticker/example/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:fixed_ticker/fixed_ticker.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/scheduler.dart';
 
 /// Launches the example app.
 void main() => runApp(const FixedTickerExample());
@@ -42,63 +45,62 @@ class _HomeState extends State<_Home> {
         middle: Text('Fixed Ticker'),
       ),
       child: SafeArea(
-        child: Padding(
+        child: ListView(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                'Two independent animations under one '
-                'TickerRateScope. Both auto-sync when the '
-                'rate changes.',
-              ),
-              const SizedBox(height: 32),
-              TickerRateScope(
-                rate: _useFixedRate
-                    ? TickerRate.fps(_fps.toDouble())
-                    : const TickerRate.vsync(),
-                child: const Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _RateLabel(),
-                    SizedBox(height: 16),
-                    _BlinkingCursor(),
-                    SizedBox(height: 24),
-                    _BouncingBall(),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 32),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              'Two independent animations under one '
+              'TickerRateScope. Both auto-sync when the '
+              'rate changes.',
+            ),
+            const SizedBox(height: 32),
+            TickerRateScope(
+              rate: _useFixedRate
+                  ? TickerRate.fps(_fps.toDouble())
+                  : const TickerRate.vsync(),
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text('Fixed frame rate'),
-                  CupertinoSwitch(
-                    value: _useFixedRate,
-                    onChanged: (v) => setState(() => _useFixedRate = v),
-                  ),
+                  _RateLabel(),
+                  SizedBox(height: 16),
+                  _BlinkingCursor(),
+                  SizedBox(height: 24),
+                  _BouncingBall(),
                 ],
               ),
-              const SizedBox(height: 16),
-              IgnorePointer(
-                ignoring: !_useFixedRate,
-                child: AnimatedOpacity(
-                  opacity: _useFixedRate ? 1.0 : 0.4,
-                  duration: const Duration(milliseconds: 200),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: CupertinoSlidingSegmentedControl<int>(
-                      groupValue: _fps,
-                      onValueChanged: (v) => setState(() => _fps = v!),
-                      children: {
-                        for (final fps in _options) fps: Text('$fps fps'),
-                      },
-                    ),
+            ),
+            const SizedBox(height: 32),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Fixed frame rate'),
+                CupertinoSwitch(
+                  value: _useFixedRate,
+                  onChanged: (v) => setState(() => _useFixedRate = v),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            IgnorePointer(
+              ignoring: !_useFixedRate,
+              child: AnimatedOpacity(
+                opacity: _useFixedRate ? 1.0 : 0.4,
+                duration: const Duration(milliseconds: 200),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: CupertinoSlidingSegmentedControl<int>(
+                    groupValue: _fps,
+                    onValueChanged: (v) => setState(() => _fps = v!),
+                    children: {
+                      for (final fps in _options) fps: Text('$fps fps'),
+                    },
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 32),
+            const _SharedTickDemo(),
+          ],
         ),
       ),
     );
@@ -233,6 +235,173 @@ class _BouncingBallState extends State<_BouncingBall>
           ),
         );
       },
+    );
+  }
+}
+
+/// Shows two equal-rate tickers converging on the same shared frame even when
+/// the second ticker starts later.
+class _SharedTickDemo extends StatefulWidget {
+  const _SharedTickDemo();
+
+  @override
+  State<_SharedTickDemo> createState() => _SharedTickDemoState();
+}
+
+class _SharedTickDemoState extends State<_SharedTickDemo>
+    with FixedTickerProviderStateMixin {
+  late final Ticker _firstTicker;
+  late final Ticker _secondTicker;
+  Timer? _delayedStart;
+  int _firstTicks = 0;
+  int _secondTicks = 0;
+  Duration? _firstFrame;
+  Duration? _secondFrame;
+
+  @override
+  TickerRate get tickerRate => TickerRate.fps(2);
+
+  bool get _isAligned =>
+      _firstFrame != null &&
+      _secondFrame != null &&
+      _firstFrame == _secondFrame;
+
+  @override
+  void initState() {
+    super.initState();
+    _firstTicker = createTicker((_) => _recordTick(first: true));
+    _secondTicker = createTicker((_) => _recordTick(first: false));
+    unawaited(_firstTicker.start());
+    _delayedStart = Timer(
+      const Duration(milliseconds: 750),
+      _startSecondTicker,
+    );
+  }
+
+  void _recordTick({required bool first}) {
+    if (!mounted) return;
+    setState(() {
+      final frame = SchedulerBinding.instance.currentFrameTimeStamp;
+      if (first) {
+        _firstTicks++;
+        _firstFrame = frame;
+      } else {
+        _secondTicks++;
+        _secondFrame = frame;
+      }
+    });
+  }
+
+  void _startSecondTicker() {
+    if (!mounted) return;
+    if (_secondTicker.isActive) _secondTicker.stop();
+    setState(() => _secondFrame = null);
+    unawaited(_secondTicker.start());
+  }
+
+  @override
+  void dispose() {
+    _delayedStart?.cancel();
+    _firstTicker.dispose();
+    _secondTicker.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final secondaryLabel = CupertinoColors.secondaryLabel.resolveFrom(context);
+    final statusColor = _isAligned
+        ? CupertinoColors.activeGreen.resolveFrom(context)
+        : CupertinoColors.activeOrange.resolveFrom(context);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CupertinoColors.secondarySystemGroupedBackground.resolveFrom(
+          context,
+        ),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Shared tick scheduling',
+            style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Ticker B starts 750ms late. Both run at 2 fps, then land on the '
+            'same frame without maintaining separate timer phases.',
+            style: TextStyle(fontSize: 13, color: secondaryLabel),
+          ),
+          const SizedBox(height: 16),
+          _TickRow(label: 'Ticker A', ticks: _firstTicks),
+          const SizedBox(height: 8),
+          _TickRow(label: 'Ticker B', ticks: _secondTicks),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Icon(
+                _isAligned
+                    ? CupertinoIcons.check_mark_circled_solid
+                    : CupertinoIcons.clock,
+                size: 18,
+                color: statusColor,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  _isAligned
+                      ? 'Callbacks aligned on the same frame'
+                      : 'Ticker B is joining the shared phase…',
+                  style: TextStyle(
+                    color: statusColor,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: _startSecondTicker,
+            child: const Text('Restart ticker B late'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TickRow extends StatelessWidget {
+  const _TickRow({required this.label, required this.ticks});
+
+  final String label;
+  final int ticks;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: CupertinoColors.activeBlue.resolveFrom(context),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(child: Text(label)),
+        Text(
+          '$ticks ticks',
+          style: TextStyle(
+            color: CupertinoColors.secondaryLabel.resolveFrom(context),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/packages/fixed_ticker/example/lib/main.dart
+++ b/packages/fixed_ticker/example/lib/main.dart
@@ -294,9 +294,17 @@ class _SharedTickDemoState extends State<_SharedTickDemo>
 
   void _startSecondTicker() {
     if (!mounted) return;
+    unawaited(_secondTicker.start());
+  }
+
+  void _restartSecondTickerLate() {
+    _delayedStart?.cancel();
     if (_secondTicker.isActive) _secondTicker.stop();
     setState(() => _secondFrame = null);
-    unawaited(_secondTicker.start());
+    _delayedStart = Timer(
+      const Duration(milliseconds: 750),
+      _startSecondTicker,
+    );
   }
 
   @override
@@ -366,7 +374,7 @@ class _SharedTickDemoState extends State<_SharedTickDemo>
           const SizedBox(height: 8),
           CupertinoButton(
             padding: EdgeInsets.zero,
-            onPressed: _startSecondTicker,
+            onPressed: _restartSecondTickerLate,
             child: const Text('Restart ticker B late'),
           ),
         ],

--- a/packages/fixed_ticker/example/lib/main.dart
+++ b/packages/fixed_ticker/example/lib/main.dart
@@ -250,6 +250,8 @@ class _SharedTickDemo extends StatefulWidget {
 
 class _SharedTickDemoState extends State<_SharedTickDemo>
     with FixedTickerProviderStateMixin {
+  static const _lateStartDelay = Duration(milliseconds: 1500);
+
   late final Ticker _firstTicker;
   late final Ticker _secondTicker;
   Timer? _delayedStart;
@@ -272,10 +274,7 @@ class _SharedTickDemoState extends State<_SharedTickDemo>
     _firstTicker = createTicker((_) => _recordTick(first: true));
     _secondTicker = createTicker((_) => _recordTick(first: false));
     unawaited(_firstTicker.start());
-    _delayedStart = Timer(
-      const Duration(milliseconds: 750),
-      _startSecondTicker,
-    );
+    _delayedStart = Timer(_lateStartDelay, _startSecondTicker);
   }
 
   void _recordTick({required bool first}) {
@@ -301,10 +300,7 @@ class _SharedTickDemoState extends State<_SharedTickDemo>
     _delayedStart?.cancel();
     if (_secondTicker.isActive) _secondTicker.stop();
     setState(() => _secondFrame = null);
-    _delayedStart = Timer(
-      const Duration(milliseconds: 750),
-      _startSecondTicker,
-    );
+    _delayedStart = Timer(_lateStartDelay, _startSecondTicker);
   }
 
   @override
@@ -339,7 +335,7 @@ class _SharedTickDemoState extends State<_SharedTickDemo>
           ),
           const SizedBox(height: 6),
           Text(
-            'Ticker B starts 750ms late. Both run at 2 fps, then land on the '
+            'Ticker B starts 1.5s late. Both run at 2 fps, then land on the '
             'same frame without maintaining separate timer phases.',
             style: TextStyle(fontSize: 13, color: secondaryLabel),
           ),

--- a/packages/fixed_ticker/lib/src/fixed_ticker.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker.dart
@@ -15,6 +15,11 @@ import 'package:meta/meta.dart';
 /// and fixed-rate modes (or between different fixed rates) without recreating
 /// the ticker or losing animation state.
 ///
+/// Fixed-rate tickers share a phase-aligned scheduler by default. Tickers with
+/// equal intervals request frames together, while intervals that are exact
+/// multiples naturally meet on the same scheduler boundaries. Set [shared] to
+/// `false` to retain an independent periodic timer for a ticker.
+///
 /// ## Elapsed time in fixed-rate mode
 ///
 /// The periodic timer does not compute elapsed time itself. Instead, each
@@ -47,12 +52,14 @@ class FixedTicker extends Ticker {
   FixedTicker(
     super.onTick, {
     Duration? interval,
+    bool shared = true,
     super.debugLabel,
   }) : assert(
          interval == null || interval > Duration.zero,
          'interval must be positive when non-null, got $interval.',
        ),
-       _interval = interval;
+       _interval = interval,
+       _shared = shared;
 
   /// The fixed interval between ticks, or `null` for normal vsync-driven
   /// ticking.
@@ -87,16 +94,39 @@ class FixedTicker extends Ticker {
     }
   }
 
+  /// Whether fixed-rate ticks use the shared, phase-aligned scheduler.
+  ///
+  /// This is `true` by default. Set it to `false` when this ticker needs an
+  /// independent timer and phase. Changing it while active takes effect
+  /// immediately without changing elapsed-time semantics.
+  bool get shared => _shared;
+  bool _shared;
+
+  set shared(bool value) {
+    if (_shared == value) return;
+    _stopTimer();
+    _shared = value;
+
+    if (!isActive || muted || _interval == null) return;
+
+    _startTimer(_interval!);
+    if (shouldScheduleTick) {
+      super.scheduleTick();
+    }
+  }
+
   Timer? _timer;
 
   static int _activeCount = 0;
+  static final _sharedScheduler = _SharedTickScheduler();
 
   /// Whether any [FixedTicker] instance currently has an active timer.
   ///
   /// Used by the `pumpAndSettleFixedTickers` test utility to determine when
   /// all fixed-rate animations have completed.
   @visibleForTesting
-  static bool get hasActiveTimers => _activeCount > 0;
+  static bool get hasActiveTimers =>
+      _activeCount > 0 || _sharedScheduler.hasSubscribers;
 
   @override
   void scheduleTick({bool rescheduling = false}) {
@@ -120,12 +150,20 @@ class FixedTicker extends Ticker {
   }
 
   void _startTimer(Duration interval) {
+    if (_shared) {
+      _sharedScheduler.subscribe(this, interval);
+      return;
+    }
     if (_timer?.isActive ?? false) return;
     _timer = Timer.periodic(interval, _handleTimerTick);
     _activeCount++;
   }
 
   void _restartTimer(Duration interval) {
+    if (_shared) {
+      _sharedScheduler.subscribe(this, interval);
+      return;
+    }
     if (_timer?.isActive ?? false) {
       _timer!.cancel();
       _timer = Timer.periodic(interval, _handleTimerTick);
@@ -135,6 +173,7 @@ class FixedTicker extends Ticker {
   }
 
   void _stopTimer() {
+    _sharedScheduler.unsubscribe(this);
     if (_timer?.isActive ?? false) {
       _timer!.cancel();
       _activeCount--;
@@ -147,4 +186,134 @@ class FixedTicker extends Ticker {
       super.scheduleTick();
     }
   }
+
+  void _handleSharedTick() {
+    if (shouldScheduleTick) {
+      super.scheduleTick();
+    }
+  }
+}
+
+class _SharedTickScheduler {
+  final Map<FixedTicker, _SharedTickGroup> _tickerGroups =
+      <FixedTicker, _SharedTickGroup>{};
+  final Set<_SharedTickGroup> _groups = <_SharedTickGroup>{};
+
+  bool get hasSubscribers => _tickerGroups.isNotEmpty;
+
+  void subscribe(FixedTicker ticker, Duration interval) {
+    final existingGroup = _tickerGroups[ticker];
+    if (existingGroup?.intervalFor(ticker) == interval) return;
+    unsubscribe(ticker);
+
+    _SharedTickGroup? group;
+    for (final candidate in _groups) {
+      if (candidate.canUse(interval)) {
+        group = candidate;
+        break;
+      }
+    }
+    group ??= _SharedTickGroup(this, interval)..start();
+    _groups.add(group);
+    group.add(ticker, interval);
+    _tickerGroups[ticker] = group;
+  }
+
+  void unsubscribe(FixedTicker ticker) {
+    final group = _tickerGroups.remove(ticker);
+    group?.remove(ticker);
+  }
+
+  void removeGroup(_SharedTickGroup group) {
+    _groups.remove(group);
+  }
+}
+
+class _SharedTickGroup {
+  _SharedTickGroup(this.scheduler, this.baseInterval);
+
+  final _SharedTickScheduler scheduler;
+  Duration baseInterval;
+  final Map<FixedTicker, _SharedTickSubscription> _subscriptions =
+      <FixedTicker, _SharedTickSubscription>{};
+
+  Timer? _timer;
+  int _tick = 0;
+
+  bool canUse(Duration interval) {
+    final baseMicroseconds = baseInterval.inMicroseconds;
+    final intervalMicroseconds = interval.inMicroseconds;
+    return intervalMicroseconds % baseMicroseconds == 0 ||
+        baseMicroseconds % intervalMicroseconds == 0;
+  }
+
+  Duration? intervalFor(FixedTicker ticker) {
+    return _subscriptions[ticker]?.interval;
+  }
+
+  void start() {
+    _timer = Timer.periodic(baseInterval, _handleTick);
+  }
+
+  void add(FixedTicker ticker, Duration interval) {
+    if (baseInterval.inMicroseconds % interval.inMicroseconds == 0 &&
+        baseInterval != interval) {
+      _rebase(interval);
+    }
+
+    final tickMultiple = interval.inMicroseconds ~/ baseInterval.inMicroseconds;
+    _subscriptions[ticker] = _SharedTickSubscription(
+      interval,
+      tickMultiple,
+      (_tick ~/ tickMultiple + 1) * tickMultiple,
+    );
+  }
+
+  void remove(FixedTicker ticker) {
+    _subscriptions.remove(ticker);
+    if (_subscriptions.isEmpty) {
+      _timer?.cancel();
+      _timer = null;
+      scheduler.removeGroup(this);
+    }
+  }
+
+  void _rebase(Duration interval) {
+    _timer?.cancel();
+    baseInterval = interval;
+    _tick = 0;
+    for (final subscription in _subscriptions.values) {
+      subscription.tickMultiple =
+          subscription.interval.inMicroseconds ~/ interval.inMicroseconds;
+      subscription.nextTick = subscription.tickMultiple;
+    }
+    start();
+  }
+
+  void _handleTick(Timer timer) {
+    _tick++;
+    final dueTickers = <FixedTicker>[];
+
+    for (final MapEntry(key: ticker, value: subscription)
+        in _subscriptions.entries) {
+      if (subscription.nextTick != _tick) continue;
+
+      dueTickers.add(ticker);
+      subscription.nextTick += subscription.tickMultiple;
+    }
+
+    for (final ticker in dueTickers) {
+      if (_subscriptions.containsKey(ticker)) {
+        ticker._handleSharedTick();
+      }
+    }
+  }
+}
+
+class _SharedTickSubscription {
+  _SharedTickSubscription(this.interval, this.tickMultiple, this.nextTick);
+
+  final Duration interval;
+  int tickMultiple;
+  int nextTick;
 }

--- a/packages/fixed_ticker/lib/src/fixed_ticker.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker.dart
@@ -207,17 +207,18 @@ class _SharedTickScheduler {
     if (existingGroup?.intervalFor(ticker) == interval) return;
     unsubscribe(ticker);
 
-    _SharedTickGroup? group;
-    for (final candidate in _groups) {
-      if (candidate.canUse(interval)) {
-        group = candidate;
-        break;
-      }
+    final compatibleGroups = _groups
+        .where((candidate) => candidate.canUse(interval))
+        .toList();
+    final group = compatibleGroups.firstOrNull;
+    final selectedGroup = group ?? (_SharedTickGroup(this, interval)..start());
+    _groups.add(selectedGroup);
+    selectedGroup.prepareBase(interval);
+    for (final compatibleGroup in compatibleGroups.skip(1)) {
+      selectedGroup.absorb(compatibleGroup);
     }
-    group ??= _SharedTickGroup(this, interval)..start();
-    _groups.add(group);
-    group.add(ticker, interval);
-    _tickerGroups[ticker] = group;
+    selectedGroup.add(ticker, interval);
+    _tickerGroups[ticker] = selectedGroup;
   }
 
   void unsubscribe(FixedTicker ticker) {
@@ -240,10 +241,16 @@ class _SharedTickGroup {
 
   Timer? _timer;
   int _tick = 0;
+  Duration? _pendingBaseInterval;
+  final Set<FixedTicker> _joinOnRebase = <FixedTicker>{};
+  final Set<FixedTicker> _alignOnRebase = <FixedTicker>{};
+  final Set<_SharedTickGroup> _groupsToAbsorbOnRebase = <_SharedTickGroup>{};
+  final Map<FixedTicker, Timer> _pendingTimers = <FixedTicker, Timer>{};
 
   bool canUse(Duration interval) {
-    return _harmonicMultiple(interval, baseInterval) != null ||
-        _harmonicMultiple(baseInterval, interval) != null;
+    final effectiveBase = _pendingBaseInterval ?? baseInterval;
+    return _harmonicMultiple(interval, effectiveBase) != null ||
+        _harmonicMultiple(effectiveBase, interval) != null;
   }
 
   Duration? intervalFor(FixedTicker ticker) {
@@ -254,10 +261,80 @@ class _SharedTickGroup {
     _timer = Timer.periodic(baseInterval, _handleTick);
   }
 
+  void prepareBase(Duration interval) {
+    final effectiveBase = _pendingBaseInterval ?? baseInterval;
+    if (interval < effectiveBase &&
+        _harmonicMultiple(effectiveBase, interval) != null) {
+      _pendingBaseInterval = interval;
+    }
+  }
+
+  void absorb(_SharedTickGroup other) {
+    if (identical(this, other)) return;
+
+    prepareBase(other._pendingBaseInterval ?? other.baseInterval);
+    if (_pendingBaseInterval != null) {
+      _groupsToAbsorbOnRebase.add(other);
+      return;
+    }
+    _absorbNow(other);
+  }
+
+  void _absorbNow(_SharedTickGroup other) {
+    other._timer?.cancel();
+    other._timer = null;
+    scheduler.removeGroup(other);
+
+    for (final entry in other._subscriptions.entries) {
+      final ticker = entry.key;
+      final interval = entry.value.interval;
+      prepareBase(interval);
+      scheduler._tickerGroups[ticker] = this;
+      if (_pendingBaseInterval != null) {
+        _subscriptions[ticker] = _SharedTickSubscription(interval, 0, 0);
+        _alignOnRebase.add(ticker);
+      } else {
+        final tickMultiple = _harmonicMultiple(interval, baseInterval)!;
+        _subscriptions[ticker] = _SharedTickSubscription(
+          interval,
+          tickMultiple,
+          (_tick ~/ tickMultiple + 1) * tickMultiple,
+        );
+      }
+    }
+    other._subscriptions.clear();
+    other._joinOnRebase.clear();
+    other._alignOnRebase.clear();
+    for (final timer in other._pendingTimers.values) {
+      timer.cancel();
+    }
+    other._pendingTimers.clear();
+    other._groupsToAbsorbOnRebase.clear();
+  }
+
   void add(FixedTicker ticker, Duration interval) {
-    final baseMultiple = _harmonicMultiple(baseInterval, interval);
-    if (baseMultiple != null && interval < baseInterval) {
-      _rebase(interval);
+    final effectiveBase = _pendingBaseInterval ?? baseInterval;
+    final baseMultiple = _harmonicMultiple(effectiveBase, interval);
+    if (baseMultiple != null && interval < effectiveBase) {
+      prepareBase(interval);
+    }
+
+    final pendingBaseInterval = _pendingBaseInterval;
+    if (pendingBaseInterval != null) {
+      final tickMultiple = _harmonicMultiple(interval, pendingBaseInterval)!;
+      _subscriptions[ticker] = _SharedTickSubscription(
+        interval,
+        tickMultiple,
+        0,
+      );
+      _joinOnRebase.add(ticker);
+      _pendingTimers[ticker] = Timer.periodic(interval, (_) {
+        if (_joinOnRebase.contains(ticker) &&
+            _subscriptions.containsKey(ticker)) {
+          ticker._handleSharedTick();
+        }
+      });
+      return;
     }
 
     final tickMultiple = _harmonicMultiple(interval, baseInterval)!;
@@ -270,6 +347,9 @@ class _SharedTickGroup {
 
   void remove(FixedTicker ticker) {
     _subscriptions.remove(ticker);
+    _joinOnRebase.remove(ticker);
+    _alignOnRebase.remove(ticker);
+    _pendingTimers.remove(ticker)?.cancel();
     if (_subscriptions.isEmpty) {
       _timer?.cancel();
       _timer = null;
@@ -277,19 +357,52 @@ class _SharedTickGroup {
     }
   }
 
-  void _rebase(Duration interval) {
+  void _rebase(Duration interval, List<FixedTicker> dueTickers) {
     _timer?.cancel();
+    for (final group in _groupsToAbsorbOnRebase.toList()) {
+      _absorbNow(group);
+    }
+    _groupsToAbsorbOnRebase.clear();
+    final oldBaseInterval = baseInterval;
+    final oldTick = _tick;
+    final baseMultiple = _harmonicMultiple(oldBaseInterval, interval)!;
     baseInterval = interval;
-    _tick = 0;
-    for (final subscription in _subscriptions.values) {
+    _tick = oldTick * baseMultiple;
+    for (final entry in _subscriptions.entries) {
+      final ticker = entry.key;
+      final subscription = entry.value;
       final tickMultiple = _harmonicMultiple(
         subscription.interval,
         interval,
       )!;
-      subscription
-        ..tickMultiple = tickMultiple
-        ..nextTick = tickMultiple;
+      if (_joinOnRebase.contains(ticker)) {
+        dueTickers.add(ticker);
+        subscription
+          ..tickMultiple = tickMultiple
+          ..nextTick = _tick + tickMultiple;
+      } else if (_alignOnRebase.contains(ticker)) {
+        var nextTick =
+            ((_tick + tickMultiple - 1) ~/ tickMultiple) * tickMultiple;
+        if (nextTick == _tick) {
+          dueTickers.add(ticker);
+          nextTick += tickMultiple;
+        }
+        subscription
+          ..tickMultiple = tickMultiple
+          ..nextTick = nextTick;
+      } else {
+        subscription
+          ..tickMultiple = tickMultiple
+          ..nextTick *= baseMultiple;
+      }
     }
+    _pendingBaseInterval = null;
+    _joinOnRebase.clear();
+    _alignOnRebase.clear();
+    for (final timer in _pendingTimers.values) {
+      timer.cancel();
+    }
+    _pendingTimers.clear();
     start();
   }
 
@@ -303,6 +416,11 @@ class _SharedTickGroup {
 
       dueTickers.add(ticker);
       subscription.nextTick += subscription.tickMultiple;
+    }
+
+    final pendingBaseInterval = _pendingBaseInterval;
+    if (pendingBaseInterval != null) {
+      _rebase(pendingBaseInterval, dueTickers);
     }
 
     for (final ticker in dueTickers) {

--- a/packages/fixed_ticker/lib/src/fixed_ticker.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker.dart
@@ -283,9 +283,11 @@ class _SharedTickGroup {
     baseInterval = interval;
     _tick = 0;
     for (final subscription in _subscriptions.values) {
-      subscription.tickMultiple =
+      final tickMultiple =
           subscription.interval.inMicroseconds ~/ interval.inMicroseconds;
-      subscription.nextTick = subscription.tickMultiple;
+      subscription
+        ..tickMultiple = tickMultiple
+        ..nextTick = tickMultiple;
     }
     start();
   }

--- a/packages/fixed_ticker/lib/src/fixed_ticker.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker.dart
@@ -17,8 +17,9 @@ import 'package:meta/meta.dart';
 ///
 /// Fixed-rate tickers share a phase-aligned scheduler by default. Tickers with
 /// equal intervals request frames together, while intervals that are exact
-/// multiples naturally meet on the same scheduler boundaries. Set [shared] to
-/// `false` to retain an independent periodic timer for a ticker.
+/// multiples naturally meet on the same scheduler boundaries. The scheduler
+/// tolerates the bounded microsecond rounding introduced by FPS-derived
+/// intervals. Set [shared] to `false` to retain an independent periodic timer.
 ///
 /// ## Elapsed time in fixed-rate mode
 ///
@@ -241,10 +242,8 @@ class _SharedTickGroup {
   int _tick = 0;
 
   bool canUse(Duration interval) {
-    final baseMicroseconds = baseInterval.inMicroseconds;
-    final intervalMicroseconds = interval.inMicroseconds;
-    return intervalMicroseconds % baseMicroseconds == 0 ||
-        baseMicroseconds % intervalMicroseconds == 0;
+    return _harmonicMultiple(interval, baseInterval) != null ||
+        _harmonicMultiple(baseInterval, interval) != null;
   }
 
   Duration? intervalFor(FixedTicker ticker) {
@@ -256,12 +255,12 @@ class _SharedTickGroup {
   }
 
   void add(FixedTicker ticker, Duration interval) {
-    if (baseInterval.inMicroseconds % interval.inMicroseconds == 0 &&
-        baseInterval != interval) {
+    final baseMultiple = _harmonicMultiple(baseInterval, interval);
+    if (baseMultiple != null && interval < baseInterval) {
       _rebase(interval);
     }
 
-    final tickMultiple = interval.inMicroseconds ~/ baseInterval.inMicroseconds;
+    final tickMultiple = _harmonicMultiple(interval, baseInterval)!;
     _subscriptions[ticker] = _SharedTickSubscription(
       interval,
       tickMultiple,
@@ -283,8 +282,10 @@ class _SharedTickGroup {
     baseInterval = interval;
     _tick = 0;
     for (final subscription in _subscriptions.values) {
-      final tickMultiple =
-          subscription.interval.inMicroseconds ~/ interval.inMicroseconds;
+      final tickMultiple = _harmonicMultiple(
+        subscription.interval,
+        interval,
+      )!;
       subscription
         ..tickMultiple = tickMultiple
         ..nextTick = tickMultiple;
@@ -318,4 +319,17 @@ class _SharedTickSubscription {
   final Duration interval;
   int tickMultiple;
   int nextTick;
+}
+
+int? _harmonicMultiple(Duration longer, Duration shorter) {
+  final longerMicroseconds = longer.inMicroseconds;
+  final shorterMicroseconds = shorter.inMicroseconds;
+  if (longerMicroseconds < shorterMicroseconds) return null;
+
+  final multiple =
+      (longerMicroseconds + shorterMicroseconds ~/ 2) ~/ shorterMicroseconds;
+  final roundingError = (longerMicroseconds - shorterMicroseconds * multiple)
+      .abs();
+  final maximumRoundingError = (multiple + 1) ~/ 2;
+  return roundingError <= maximumRoundingError ? multiple : null;
 }

--- a/packages/fixed_ticker/lib/src/fixed_ticker_provider.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker_provider.dart
@@ -43,14 +43,28 @@ mixin SingleFixedTickerProviderStateMixin<T extends StatefulWidget> on State<T>
   TickerRate get tickerRate =>
       TickerRateScope.maybeOf(context) ?? const TickerRate.vsync();
 
+  /// Whether fixed-rate tickers use the shared, phase-aligned scheduler.
+  ///
+  /// Override this and return `false` to give this provider's ticker an
+  /// independent timer. Call [updateTickerRate] after changing the value.
+  bool get shareTicks => true;
+
   FixedTicker? _ticker;
   TickerRate? _lastSyncedRate;
+  bool? _lastSyncedShareTicks;
 
   void _syncTickerRate() {
     final desired = tickerRate;
-    if (desired == _lastSyncedRate) return;
+    final desiredShareTicks = shareTicks;
+    if (desired == _lastSyncedRate &&
+        desiredShareTicks == _lastSyncedShareTicks) {
+      return;
+    }
     _lastSyncedRate = desired;
-    _ticker?.interval = desired.interval;
+    _lastSyncedShareTicks = desiredShareTicks;
+    _ticker
+      ?..shared = desiredShareTicks
+      ..interval = desired.interval;
   }
 
   @override
@@ -85,6 +99,7 @@ mixin SingleFixedTickerProviderStateMixin<T extends StatefulWidget> on State<T>
     _ticker = FixedTicker(
       onTick,
       interval: _lastSyncedRate?.interval,
+      shared: _lastSyncedShareTicks ?? shareTicks,
       debugLabel: kDebugMode ? 'created by ${describeIdentity(this)}' : null,
     );
     _updateTickerModeNotifier();
@@ -226,16 +241,30 @@ mixin FixedTickerProviderStateMixin<T extends StatefulWidget> on State<T>
   TickerRate get tickerRate =>
       TickerRateScope.maybeOf(context) ?? const TickerRate.vsync();
 
+  /// Whether fixed-rate tickers use the shared, phase-aligned scheduler.
+  ///
+  /// Override this and return `false` to give this provider's tickers
+  /// independent timers. Call [updateTickerRate] after changing the value.
+  bool get shareTicks => true;
+
   Set<Ticker>? _tickers;
   TickerRate? _lastSyncedRate;
+  bool? _lastSyncedShareTicks;
 
   void _syncTickerRate() {
     final desired = tickerRate;
-    if (desired == _lastSyncedRate) return;
+    final desiredShareTicks = shareTicks;
+    if (desired == _lastSyncedRate &&
+        desiredShareTicks == _lastSyncedShareTicks) {
+      return;
+    }
     _lastSyncedRate = desired;
+    _lastSyncedShareTicks = desiredShareTicks;
     if (_tickers == null) return;
     for (final ticker in _tickers!) {
-      (ticker as _WidgetFixedTicker).interval = desired.interval;
+      (ticker as _WidgetFixedTicker)
+        ..shared = desiredShareTicks
+        ..interval = desired.interval;
     }
   }
 
@@ -249,6 +278,7 @@ mixin FixedTickerProviderStateMixin<T extends StatefulWidget> on State<T>
     final result = _WidgetFixedTicker(
       onTick,
       interval: _lastSyncedRate?.interval,
+      shared: _lastSyncedShareTicks ?? shareTicks,
       creator: this,
       debugLabel: kDebugMode ? 'created by ${describeIdentity(this)}' : null,
     );
@@ -370,6 +400,7 @@ class _WidgetFixedTicker extends FixedTicker {
   _WidgetFixedTicker(
     super.onTick, {
     required super.interval,
+    required super.shared,
     required FixedTickerProviderStateMixin creator,
     super.debugLabel,
   }) : _creator = creator;

--- a/packages/fixed_ticker/test/fixed_ticker_provider_test.dart
+++ b/packages/fixed_ticker/test/fixed_ticker_provider_test.dart
@@ -46,6 +46,19 @@ void main() {
       );
     });
 
+    testWidgets('shareTicks can opt out of shared scheduling', (tester) async {
+      Ticker? ticker;
+      await tester.pumpWidget(
+        _CustomIntervalSingleTickerWidget(
+          interval: const Duration(milliseconds: 100),
+          shareTicks: false,
+          onTicker: (value) => ticker = value,
+        ),
+      );
+
+      expect((ticker! as FixedTicker).shared, isFalse);
+    });
+
     testWidgets('throws on second createTicker call', (tester) async {
       FlutterError? error;
       await tester.pumpWidget(
@@ -233,6 +246,22 @@ void main() {
           (ticker as FixedTicker).interval,
           const Duration(milliseconds: 50),
         );
+      }
+    });
+
+    testWidgets('shareTicks applies to every created ticker', (tester) async {
+      final tickers = <Ticker>[];
+      await tester.pumpWidget(
+        _CustomIntervalMultiTickerWidget(
+          interval: const Duration(milliseconds: 50),
+          tickerCount: 2,
+          shareTicks: false,
+          onTickers: tickers.addAll,
+        ),
+      );
+
+      for (final ticker in tickers) {
+        expect((ticker as FixedTicker).shared, isFalse);
       }
     });
 
@@ -611,10 +640,12 @@ class _MultiTickerTestWidgetState extends State<_MultiTickerTestWidget>
 class _CustomIntervalSingleTickerWidget extends StatefulWidget {
   const _CustomIntervalSingleTickerWidget({
     required this.interval,
+    this.shareTicks = true,
     this.onTicker,
   });
 
   final Duration interval;
+  final bool shareTicks;
   final void Function(Ticker)? onTicker;
 
   @override
@@ -627,6 +658,9 @@ class _CustomIntervalSingleTickerWidgetState
     with SingleFixedTickerProviderStateMixin {
   @override
   TickerRate get tickerRate => TickerRate.interval(widget.interval);
+
+  @override
+  bool get shareTicks => widget.shareTicks;
 
   @override
   void initState() {
@@ -644,11 +678,13 @@ class _CustomIntervalMultiTickerWidget extends StatefulWidget {
   const _CustomIntervalMultiTickerWidget({
     required this.interval,
     required this.tickerCount,
+    this.shareTicks = true,
     this.onTickers,
   });
 
   final Duration interval;
   final int tickerCount;
+  final bool shareTicks;
   final void Function(List<Ticker>)? onTickers;
 
   @override
@@ -663,6 +699,9 @@ class _CustomIntervalMultiTickerWidgetState
 
   @override
   TickerRate get tickerRate => TickerRate.interval(widget.interval);
+
+  @override
+  bool get shareTicks => widget.shareTicks;
 
   @override
   void initState() {

--- a/packages/fixed_ticker/test/fixed_ticker_test.dart
+++ b/packages/fixed_ticker/test/fixed_ticker_test.dart
@@ -392,6 +392,40 @@ void main() {
         ..dispose();
     });
 
+    testWidgets('fps multiples align despite microsecond rounding', (
+      tester,
+    ) async {
+      final fastInterval = TickerRate.fps(30).interval!;
+      final slowInterval = TickerRate.fps(15).interval!;
+      expect(slowInterval.inMicroseconds, fastInterval.inMicroseconds * 2 + 1);
+
+      final fastElapsed = <Duration>[];
+      final slowElapsed = <Duration>[];
+      final fast = FixedTicker(fastElapsed.add, interval: fastInterval);
+      final slow = FixedTicker(slowElapsed.add, interval: slowInterval);
+
+      unawaited(fast.start());
+      unawaited(slow.start());
+      await tester.pump();
+      fastElapsed.clear();
+      slowElapsed.clear();
+
+      await tester.pump(fastInterval);
+      expect(fastElapsed, hasLength(1));
+      expect(slowElapsed, isEmpty);
+
+      await tester.pump(fastInterval);
+      expect(fastElapsed, hasLength(2));
+      expect(slowElapsed, hasLength(1));
+
+      fast
+        ..stop()
+        ..dispose();
+      slow
+        ..stop()
+        ..dispose();
+    });
+
     testWidgets('shared false retains an independent phase', (tester) async {
       const interval = Duration(milliseconds: 50);
       final sharedElapsed = <Duration>[];

--- a/packages/fixed_ticker/test/fixed_ticker_test.dart
+++ b/packages/fixed_ticker/test/fixed_ticker_test.dart
@@ -295,6 +295,173 @@ void main() {
     });
   });
 
+  group('shared fixed-rate scheduling', () {
+    testWidgets('equal intervals join the same phase', (tester) async {
+      const interval = Duration(milliseconds: 50);
+      final firstElapsed = <Duration>[];
+      final secondElapsed = <Duration>[];
+      final first = FixedTicker(firstElapsed.add, interval: interval);
+      final second = FixedTicker(secondElapsed.add, interval: interval);
+
+      unawaited(first.start());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+
+      unawaited(second.start());
+      await tester.pump();
+      firstElapsed.clear();
+      secondElapsed.clear();
+
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(firstElapsed, hasLength(1));
+      expect(secondElapsed, hasLength(1));
+
+      first
+        ..stop()
+        ..dispose();
+      second
+        ..stop()
+        ..dispose();
+    });
+
+    testWidgets('multiple intervals meet on shared boundaries', (tester) async {
+      const fastInterval = Duration(milliseconds: 50);
+      const slowInterval = Duration(milliseconds: 100);
+      final fastElapsed = <Duration>[];
+      final slowElapsed = <Duration>[];
+      final fast = FixedTicker(fastElapsed.add, interval: fastInterval);
+      final slow = FixedTicker(slowElapsed.add, interval: slowInterval);
+
+      unawaited(fast.start());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+
+      unawaited(slow.start());
+      await tester.pump();
+      fastElapsed.clear();
+      slowElapsed.clear();
+
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(fastElapsed, hasLength(1));
+      expect(slowElapsed, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(fastElapsed, hasLength(2));
+      expect(slowElapsed, hasLength(1));
+
+      fast
+        ..stop()
+        ..dispose();
+      slow
+        ..stop()
+        ..dispose();
+    });
+
+    testWidgets('a faster ticker rephases an existing slower group', (
+      tester,
+    ) async {
+      const fastInterval = Duration(milliseconds: 50);
+      const slowInterval = Duration(milliseconds: 100);
+      final fastElapsed = <Duration>[];
+      final slowElapsed = <Duration>[];
+      final slow = FixedTicker(slowElapsed.add, interval: slowInterval);
+      final fast = FixedTicker(fastElapsed.add, interval: fastInterval);
+
+      unawaited(slow.start());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+
+      unawaited(fast.start());
+      await tester.pump();
+      fastElapsed.clear();
+      slowElapsed.clear();
+
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(fastElapsed, hasLength(1));
+      expect(slowElapsed, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(fastElapsed, hasLength(2));
+      expect(slowElapsed, hasLength(1));
+
+      fast
+        ..stop()
+        ..dispose();
+      slow
+        ..stop()
+        ..dispose();
+    });
+
+    testWidgets('shared false retains an independent phase', (tester) async {
+      const interval = Duration(milliseconds: 50);
+      final sharedElapsed = <Duration>[];
+      final independentElapsed = <Duration>[];
+      final shared = FixedTicker(sharedElapsed.add, interval: interval);
+      final independent = FixedTicker(
+        independentElapsed.add,
+        interval: interval,
+        shared: false,
+      );
+
+      unawaited(shared.start());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+
+      unawaited(independent.start());
+      await tester.pump();
+      sharedElapsed.clear();
+      independentElapsed.clear();
+
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(sharedElapsed, hasLength(1));
+      expect(independentElapsed, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(sharedElapsed, hasLength(1));
+      expect(independentElapsed, hasLength(1));
+
+      shared
+        ..stop()
+        ..dispose();
+      independent
+        ..stop()
+        ..dispose();
+    });
+
+    testWidgets('changing shared mode rephases an active ticker', (
+      tester,
+    ) async {
+      const interval = Duration(milliseconds: 50);
+      final anchor = FixedTicker((_) {}, interval: interval);
+      final elapsed = <Duration>[];
+      final ticker = FixedTicker(
+        elapsed.add,
+        interval: interval,
+        shared: false,
+      );
+
+      unawaited(anchor.start());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
+      unawaited(ticker.start());
+      await tester.pump();
+      elapsed.clear();
+
+      ticker.shared = true;
+      await tester.pump();
+      elapsed.clear();
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(elapsed, hasLength(1));
+
+      anchor
+        ..stop()
+        ..dispose();
+      ticker
+        ..stop()
+        ..dispose();
+    });
+  });
+
   group('FixedTicker (null interval / normal mode)', () {
     testWidgets('behaves like a normal Ticker when interval is null', (
       tester,

--- a/packages/fixed_ticker/test/shared_scheduler_adversarial_test.dart
+++ b/packages/fixed_ticker/test/shared_scheduler_adversarial_test.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+
+import 'package:fixed_ticker/fixed_ticker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('shared scheduler adversarial behavior', () {
+    testWidgets(
+      'joining a faster rate does not postpone an already-running ticker',
+      (tester) async {
+        const slowInterval = Duration(milliseconds: 100);
+        const fastInterval = Duration(milliseconds: 50);
+        final slowElapsed = <Duration>[];
+        final slow = FixedTicker(slowElapsed.add, interval: slowInterval);
+        final fast = FixedTicker((_) {}, interval: fastInterval);
+        try {
+          unawaited(slow.start());
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 75));
+
+          unawaited(fast.start());
+          await tester.pump();
+          slowElapsed.clear();
+
+          await tester.pump(const Duration(milliseconds: 25));
+
+          expect(
+            slowElapsed,
+            hasLength(1),
+            reason:
+                'The slow ticker was already 75ms into its 100ms period. '
+                'Joining a harmonic ticker must not stretch that period.',
+          );
+        } finally {
+          _disposeTickers([slow, fast]);
+        }
+      },
+    );
+
+    testWidgets(
+      'a common faster rate synchronizes previously separate harmonic groups',
+      (tester) async {
+        const hundredMilliseconds = Duration(milliseconds: 100);
+        const hundredFiftyMilliseconds = Duration(milliseconds: 150);
+        const commonInterval = Duration(milliseconds: 50);
+        var pumpNumber = 0;
+        final hundredMillisecondTicks = <int>[];
+        final hundredFiftyMillisecondTicks = <int>[];
+        final commonTicks = <int>[];
+        final hundred = FixedTicker(
+          (_) => hundredMillisecondTicks.add(pumpNumber),
+          interval: hundredMilliseconds,
+        );
+        final hundredFifty = FixedTicker(
+          (_) => hundredFiftyMillisecondTicks.add(pumpNumber),
+          interval: hundredFiftyMilliseconds,
+        );
+        final common = FixedTicker(
+          (_) => commonTicks.add(pumpNumber),
+          interval: commonInterval,
+        );
+        try {
+          unawaited(hundred.start());
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 25));
+          unawaited(hundredFifty.start());
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 25));
+          unawaited(common.start());
+          await tester.pump();
+          hundredMillisecondTicks.clear();
+          hundredFiftyMillisecondTicks.clear();
+          commonTicks.clear();
+
+          for (pumpNumber = 1; pumpNumber <= 12; pumpNumber++) {
+            await tester.pump(const Duration(milliseconds: 25));
+          }
+
+          final commonBoundaries = hundredMillisecondTicks
+              .toSet()
+              .intersection(hundredFiftyMillisecondTicks.toSet())
+              .intersection(commonTicks.toSet());
+          expect(
+            commonBoundaries,
+            isNotEmpty,
+            reason:
+                '50ms is a common divisor of 100ms and 150ms, so all three '
+                'rates must share their 300ms boundary. Observed pump numbers: '
+                '100ms=$hundredMillisecondTicks, '
+                '150ms=$hundredFiftyMillisecondTicks, 50ms=$commonTicks.',
+          );
+        } finally {
+          _disposeTickers([hundred, hundredFifty, common]);
+        }
+      },
+    );
+
+    testWidgets('a late equal-rate ticker joins the next shared boundary', (
+      tester,
+    ) async {
+      const interval = Duration(milliseconds: 80);
+      final firstElapsed = <Duration>[];
+      final secondElapsed = <Duration>[];
+      final first = FixedTicker(firstElapsed.add, interval: interval);
+      final second = FixedTicker(secondElapsed.add, interval: interval);
+      try {
+        unawaited(first.start());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 70));
+        unawaited(second.start());
+        await tester.pump();
+        firstElapsed.clear();
+        secondElapsed.clear();
+
+        await tester.pump(const Duration(milliseconds: 10));
+
+        expect(firstElapsed, hasLength(1));
+        expect(secondElapsed, hasLength(1));
+      } finally {
+        _disposeTickers([first, second]);
+      }
+    });
+
+    testWidgets('opting out while active establishes an independent phase', (
+      tester,
+    ) async {
+      const interval = Duration(milliseconds: 60);
+      final anchorElapsed = <Duration>[];
+      final optedOutElapsed = <Duration>[];
+      final anchor = FixedTicker(anchorElapsed.add, interval: interval);
+      final optedOut = FixedTicker(optedOutElapsed.add, interval: interval);
+      try {
+        unawaited(anchor.start());
+        unawaited(optedOut.start());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 30));
+        optedOut.shared = false;
+        await tester.pump();
+        anchorElapsed.clear();
+        optedOutElapsed.clear();
+
+        await tester.pump(const Duration(milliseconds: 30));
+        expect(anchorElapsed, hasLength(1));
+        expect(optedOutElapsed, isEmpty);
+
+        await tester.pump(const Duration(milliseconds: 30));
+        expect(anchorElapsed, hasLength(1));
+        expect(optedOutElapsed, hasLength(1));
+      } finally {
+        _disposeTickers([anchor, optedOut]);
+      }
+    });
+
+    testWidgets('one subscriber stopping on tick does not suppress its peer', (
+      tester,
+    ) async {
+      const interval = Duration(milliseconds: 40);
+      late FixedTicker selfStopping;
+      final selfTicks = <Duration>[];
+      final peerTicks = <Duration>[];
+      selfStopping = FixedTicker(
+        (elapsed) {
+          selfTicks.add(elapsed);
+          if (elapsed > Duration.zero) selfStopping.stop();
+        },
+        interval: interval,
+      );
+      final peer = FixedTicker(peerTicks.add, interval: interval);
+      try {
+        unawaited(selfStopping.start());
+        unawaited(peer.start());
+        await tester.pump();
+        selfTicks.clear();
+        peerTicks.clear();
+
+        await tester.pump(interval);
+
+        expect(selfTicks, hasLength(1));
+        expect(peerTicks, hasLength(1));
+        expect(selfStopping.isActive, isFalse);
+        expect(peer.isActive, isTrue);
+        expect(FixedTicker.hasActiveTimers, isTrue);
+
+        await tester.pump(interval);
+        expect(selfTicks, hasLength(1));
+        expect(peerTicks, hasLength(2));
+      } finally {
+        _disposeTickers([selfStopping, peer]);
+      }
+    });
+
+    testWidgets('muting and rejoining one ticker does not rephase its peer', (
+      tester,
+    ) async {
+      const interval = Duration(milliseconds: 50);
+      final anchorElapsed = <Duration>[];
+      final rejoiningElapsed = <Duration>[];
+      final anchor = FixedTicker(anchorElapsed.add, interval: interval);
+      final rejoining = FixedTicker(rejoiningElapsed.add, interval: interval);
+      try {
+        unawaited(anchor.start());
+        unawaited(rejoining.start());
+        await tester.pump();
+        await tester.pump(interval);
+        rejoining.muted = true;
+        anchorElapsed.clear();
+        rejoiningElapsed.clear();
+
+        await tester.pump(const Duration(milliseconds: 25));
+        rejoining.muted = false;
+        await tester.pump();
+        rejoiningElapsed.clear();
+        await tester.pump(const Duration(milliseconds: 25));
+
+        expect(anchorElapsed, hasLength(1));
+        expect(rejoiningElapsed, hasLength(1));
+      } finally {
+        _disposeTickers([anchor, rejoining]);
+      }
+    });
+
+    testWidgets('removing the fastest subscriber preserves slower cadence', (
+      tester,
+    ) async {
+      const fastInterval = Duration(milliseconds: 50);
+      const slowInterval = Duration(milliseconds: 100);
+      final fast = FixedTicker((_) {}, interval: fastInterval);
+      final slowElapsed = <Duration>[];
+      final slow = FixedTicker(slowElapsed.add, interval: slowInterval);
+      try {
+        unawaited(fast.start());
+        unawaited(slow.start());
+        await tester.pump();
+        await tester.pump(fastInterval);
+        fast.stop();
+        slowElapsed.clear();
+
+        await tester.pump(fastInterval);
+
+        expect(slowElapsed, hasLength(1));
+        expect(slow.isActive, isTrue);
+        expect(FixedTicker.hasActiveTimers, isTrue);
+      } finally {
+        _disposeTickers([fast, slow]);
+      }
+    });
+  });
+}
+
+void _disposeTickers(Iterable<FixedTicker> tickers) {
+  for (final ticker in tickers) {
+    if (ticker.isActive) ticker.stop();
+    ticker.dispose();
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

- synchronize equal fixed ticker intervals on one shared timer phase by default
- align harmonic intervals on common tick generations, including bounded microsecond rounding from `TickerRate.fps(...)`
- preserve active ticker deadlines while rebasing to a newly joined faster rate
- merge all compatible scheduler groups when a common harmonic rate joins
- support mutable per-ticker and provider-level opt-out for independent scheduling
- preserve existing vsync, elapsed-time, muting, interval-switching, and lifecycle behavior
- document the shared scheduler and include fresh-context adversarial regression coverage
- add an interactive example showing a late-started ticker joining an existing shared phase

[shared_ticker_alignment_trimmed_demo.mp4](https://cursor.com/agents/bc-21d710f9-1ef9-4386-b959-f30fe148f0c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared_ticker_alignment_trimmed_demo.mp4)

## Validation

- `flutter test` — 105 tests passed, including all 7 adversarial scheduler tests
- `dart analyze . --fatal-infos` in `packages/fixed_ticker/example` — no issues
- manual browser walkthrough — late restart visibly transitions from joining to aligned; existing rate and vsync controls remain functional

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d710f9-1ef9-4386-b959-f30fe148f0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d710f9-1ef9-4386-b959-f30fe148f0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

