### PR TITLE
chore: ignore EquatableMixin deprecations

### DIFF
--- a/packages/heroine/lib/src/shuttle_builders.dart
+++ b/packages/heroine/lib/src/shuttle_builders.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 ///
 /// Basically a callable class that matches the signature of
 /// [HeroFlightShuttleBuilder] and offers a convenience method.
+// ignore: deprecated_member_use
 abstract class HeroineShuttleBuilder with EquatableMixin {
   /// Creates a new [HeroineShuttleBuilder].
   const HeroineShuttleBuilder({

--- a/packages/motor/lib/src/motion_sequence.dart
+++ b/packages/motor/lib/src/motion_sequence.dart
@@ -49,6 +49,7 @@ typedef ValueWithMotion<T> = (T value, Motion motion);
 /// ```
 /// {@endtemplate}
 @immutable
+// ignore: deprecated_member_use
 abstract class MotionSequence<P, T extends Object> with EquatableMixin {
   /// {@macro MotionSequence}
   const MotionSequence();

--- a/packages/snaptest/lib/src/snaptest_settings.dart
+++ b/packages/snaptest/lib/src/snaptest_settings.dart
@@ -55,6 +55,7 @@ import 'package:snaptest/src/constants.dart';
 ///   },
 /// );
 /// ```
+// ignore: deprecated_member_use
 class SnaptestSettings with EquatableMixin {
   /// Creates screenshot settings for debugging and testing.
   ///


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add narrow inline suppressions for the upstream `EquatableMixin` deprecation in `heroine`, `motor`, and `snaptest` so fatal-info analysis can pass without disabling other deprecation diagnostics.

## Validation

- `melos analyze` — all 15 packages pass with fatal infos enabled

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes (analysis-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d710f9-1ef9-4386-b959-f30fe148f0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d710f9-1ef9-4386-b959-f30fe148f0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

