### PR TITLE
fix(snaptest): preserve active device variant during capture

### DIFF
--- a/packages/snaptest/lib/src/snap.dart
+++ b/packages/snaptest/lib/src/snap.dart
@@ -632,11 +632,15 @@ Future<T?> _runInFakeDevice<T>(
   final binding = TestWidgetsFlutterBinding.instance;
   await binding.pump(Duration.zero);
 
-  final restoreView = setTestViewForDevice(device, orientation);
+  final deviceIsAlreadyConfigured =
+      activeDeviceVariant == (device, orientation);
+  final restoreView = deviceIsAlreadyConfigured
+      ? null
+      : setTestViewForDevice(device, orientation);
 
   final result = await maybeRunAsync(fn);
 
-  restoreView();
+  restoreView?.call();
 
   await binding.pump(Duration.zero);
 

--- a/packages/snaptest/test/snapper_test.dart
+++ b/packages/snaptest/test/snapper_test.dart
@@ -145,6 +145,34 @@ void main() {
         });
       });
 
+      testWidgets(
+        'does not rebuild when the device variant is already active',
+        variant: TestDevicesVariant({Devices.ios.iPhone16Pro}),
+        (tester) async {
+          var buildCount = 0;
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: LayoutBuilder(
+                builder: (context, constraints) {
+                  buildCount++;
+                  return const Text(
+                    'Visible text',
+                    style: TextStyle(fontFamily: '.SF UI Text'),
+                  );
+                },
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          final buildCountBeforeSnap = buildCount;
+
+          await snap(name: 'already_active_device');
+
+          expect(buildCount, buildCountBeforeSnap);
+        },
+      );
+
       snapTest(
         'appends counter when snap is called multiple times',
         (tester) async {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Avoid reapplying and restoring view metrics when `TestDevicesVariant` has already configured the device and orientation requested by a snap. This prevents responsive rebuilds and entry animations from restarting immediately before capture.

Adds a regression test that records responsive widget builds and verifies `snap()` does not trigger another build for an already-active device variant.

## Validation

- `flutter test packages/snaptest/test` — 37 tests passed
- `flutter analyze packages/snaptest` — no issues found

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a623a3e9-f799-42fe-bd9d-646e4fb81e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a623a3e9-f799-42fe-bd9d-646e4fb81e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

