### PR TITLE
perf(motor): cut hot-path allocs and add AC benchmark harness

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,5 @@
+.dart_tool/
+.build/
+results/
+*.json
+!pubspec.yaml

--- a/benchmark/ANALYSIS.md
+++ b/benchmark/ANALYSIS.md
@@ -1,0 +1,74 @@
+# Analysis report: Motor vs AnimationController
+
+**Source:** `benchmark/results/full.json` (also `latest.json`)  
+**Config:** full — warmup 60, measure 240 frames, 7 repeats, `BENCH_MODE=both`  
+**Date:** 2026-08-02  
+**Code:** after P1 (in-place sample + buffer alias + `growable: false`) + P2 (eager `T` cache, reuse `_waypoints`, scratch list each tick)
+
+Positive Δ = Motor slower. Layer **tick** = notify + value read; layer **pump** = wall time of `tester.pump`.
+
+## Verdict
+
+Motor is at **parity or faster** on most practical paths. Multi-track beats Flutter on pump from ~50 tracks (×500: **−11.8%**). 1D spring is **−2%** pump. Interrupt improved clearly (pump **+27%**, ~+48% before P2). `VelocityTracking.on` is still ~8× vs off.
+
+## Main results (p50)
+
+| Scenario | Tick Δ | Pump Δ |
+|---|---:|---:|
+| Single curve (1D) | +170% | **+11.3%** |
+| Single spring (1D) | +220% | **−2.0%** |
+| Offset spring (2D) | +240% | **+4.8%** |
+| Interrupt / retarget | +167% | **+27.0%** |
+| Widget rebuild | **−23%** | **−22.9%** |
+| Manual set (vel off) | +271% | — |
+| Velocity tracking on vs off | **+723%** | — |
+
+### Multi-track scale
+
+| Tracks | Pump Δ | Tick Δ | Flutter pump | Motor pump |
+|---:|---:|---:|---:|---:|
+| 1 | +0.7% | +163% | 23.9 | 24.1 |
+| 10 | +7.0% | +317% | 25.0 | 26.8 |
+| 50 | **−9.7%** | +220% | 33.4 | 30.2 |
+| 100 | **−8.2%** | +196% | 41.8 | 38.4 |
+| 250 | **−12.1%** | +249% | 69.4 | 61.0 |
+| 500 | **−11.8%** | +234% | 107.0 | 94.4 |
+
+### vs full suite before P2
+
+| Metric | Pre-P2 | Post-P2 |
+|---|---:|---:|
+| Spring 1D pump | +0.2% | **−2.0%** |
+| Offset 2D pump | +1.0% | +4.8% |
+| Interrupt pump | +47.9% | **+27.0%** |
+| Widget rebuild pump | −18.3% | **−22.9%** |
+| Multi ×500 pump | −17.6% | −11.8% |
+| Velocity tracking | +722% | +723% |
+
+Interrupt benefits clearly from waypoint reuse and fewer allocs on step changes. Multi ×500 still favors Motor; a few % of run-to-run swing is harness noise.
+
+## By group
+
+- **Parity (curve/spring/offset):** Pump ~−2–+11% — fine for normal UI.
+- **Multi-track:** Cross-over around ~50 tracks; Motor faster as N grows.
+- **Interrupt:** +27% pump — much better than +48% before P2.
+- **Widget rebuild:** Motor ~23% faster on both tick and pump.
+- **Velocity tracking:** Enable only when you need gesture velocity estimates.
+
+## Recommendations
+
+1. **P0** — Default `VelocityTracking.off` except on gesture paths.  
+2. **P1** ~~— Cut allocs in `_TrackSlot.tick`.~~ **Done**  
+3. **P2** ~~— Cache denormalized values / cut short-lived allocs.~~ **Done**  
+4. **P3** ~~— Full suite.~~ **Done**  
+5. **Optional** — Mutable/pooled `Simulation` if dense interrupt/retarget still shows up in profiles.
+
+## Harness note
+
+Status-driven spring ping-pong must listen for both `completed` and `dismissed` (Motor reports `dismissed` when settling back to `initialValue`).
+
+## Limits
+
+Debug VM · WidgetTester (not AOT device) · tick does not include all simulation advance before notify · n=7. Guidance for hot-path design, not a production SLA.
+
+Canvas: `canvases/motor-bench-analysis.canvas.tsx`

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,60 @@
+# Motor vs AnimationController benchmarks
+
+Microbenchmark suite comparing [motor](../packages/motor) to Flutter's
+`AnimationController`.
+
+Absolute µs include harness noise — read **Δ p50** (and p90 Δ). Prefer larger
+multi-track counts; `BENCH_QUICK=1` is smoke only.
+
+## Layers (`BENCH_MODE`)
+
+| Mode | Measures |
+|---|---|
+| `tick` | Time inside the animation listener (notify + value read) |
+| `pump` | Wall time of `tester.pump` loops (framework + tick) |
+| `both` (default) | Record both layers per run |
+
+## Scenarios
+
+| ID | Comparison |
+|---|---|
+| `single_curve` | Looping curve, 1D |
+| `single_spring` | Status-driven spring ping-pong (matched hot path) |
+| `offset_spring` | Offset spring vs 2× AC |
+| `multi_track_1/10/50/100/250/500` | 1 ticker × N tracks vs N controllers |
+| `interrupt_retarget` | Mid-flight retarget |
+| `widget_rebuild` | `TrackBuilder` vs `AnimatedBuilder` |
+| `manual_set` | `set` (velocity off) vs `AC.value=` |
+| `velocity_tracking_overhead` | Motor tracking on vs off |
+
+## Run
+
+```sh
+cd benchmark
+flutter pub get
+
+# Full suite (debug VM — compare Δ, not absolute µs):
+flutter test test/run_benchmarks_test.dart --reporter expanded
+
+# Smoke:
+BENCH_QUICK=1 flutter test test/run_benchmarks_test.dart --reporter expanded
+
+# Tick-only + multi-track scale + JSON:
+BENCH_MODE=tick BENCH_FILTER=multi_track,single_curve \
+  BENCH_JSON=results/multi.json \
+  flutter test test/run_benchmarks_test.dart --reporter expanded
+```
+
+Also: `melos run benchmark` from the repo root.
+
+## Output
+
+- Markdown tables per layer: baseline/primary **p50**, **Δ p50**, **p90 Δ**
+- JSON at `results/latest.json` (and `BENCH_JSON` if set)
+
+## Guarantees
+
+- Animations **must stay active** for the measured window (asserted)
+- Spring sides both use **status-driven** retarget (same hot path shape)
+- Filter prefixes match `id` or `id_*` (so `multi_track_10` does not eat `multi_track_100`)
+- Controllers are **stopped** before dispose to avoid hanging the test binding

--- a/benchmark/analysis_options.yaml
+++ b/benchmark/analysis_options.yaml
@@ -1,0 +1,19 @@
+include: package:lintervention/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - results/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+  errors:
+    prefer_int_literals: ignore
+    public_member_api_docs: ignore
+    comment_references: ignore
+    lines_longer_than_80_chars: ignore
+    sort_constructors_first: ignore
+    cascade_invocations: ignore

--- a/benchmark/lib/motor_benchmark.dart
+++ b/benchmark/lib/motor_benchmark.dart
@@ -1,0 +1,69 @@
+import 'package:motor_benchmark/src/harness.dart';
+import 'package:motor_benchmark/src/scenarios/interrupt_retarget.dart';
+import 'package:motor_benchmark/src/scenarios/manual_set.dart';
+import 'package:motor_benchmark/src/scenarios/multi_track_scale.dart';
+import 'package:motor_benchmark/src/scenarios/offset_spring.dart';
+import 'package:motor_benchmark/src/scenarios/single_curve.dart';
+import 'package:motor_benchmark/src/scenarios/single_spring.dart';
+import 'package:motor_benchmark/src/scenarios/widget_rebuild.dart';
+
+export 'package:motor_benchmark/src/harness.dart';
+export 'package:motor_benchmark/src/scenarios/interrupt_retarget.dart';
+export 'package:motor_benchmark/src/scenarios/manual_set.dart';
+export 'package:motor_benchmark/src/scenarios/multi_track_scale.dart';
+export 'package:motor_benchmark/src/scenarios/offset_spring.dart';
+export 'package:motor_benchmark/src/scenarios/single_curve.dart';
+export 'package:motor_benchmark/src/scenarios/single_spring.dart';
+export 'package:motor_benchmark/src/scenarios/widget_rebuild.dart';
+
+/// All built-in Motor vs AnimationController scenarios.
+List<BenchScenario> allScenarios() => [
+      const SingleCurveScenario(),
+      const SingleSpringScenario(),
+      const OffsetSpringScenario(),
+      const MultiTrackScaleScenario(1),
+      const MultiTrackScaleScenario(10),
+      const MultiTrackScaleScenario(50),
+      const MultiTrackScaleScenario(100),
+      const MultiTrackScaleScenario(250),
+      const MultiTrackScaleScenario(500),
+      const InterruptRetargetScenario(),
+      const WidgetRebuildScenario(),
+      const ManualSetScenario(),
+      const VelocityTrackingOverheadScenario(),
+    ];
+
+/// Filters [allScenarios] by comma-separated ids (exact or prefix match).
+List<BenchScenario> scenariosMatching(String? filter) {
+  final all = allScenarios();
+  if (filter == null || filter.trim().isEmpty) return all;
+  final ids = filter
+      .split(',')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+  return [
+    for (final id in ids)
+      ...all.where(
+        (s) => s.id == id || s.id.startsWith('${id}_'),
+      ),
+  ];
+}
+
+/// Parses `BENCH_MODE` (`tick` | `pump` | `both`).
+BenchMode parseBenchMode(String? raw) {
+  switch (raw?.trim().toLowerCase()) {
+    case 'tick':
+      return BenchMode.tick;
+    case 'pump':
+      return BenchMode.pump;
+    case 'both':
+    case null:
+    case '':
+      return BenchMode.both;
+    default:
+      throw ArgumentError(
+        'Unknown BENCH_MODE="$raw". Use tick, pump, or both.',
+      );
+  }
+}

--- a/benchmark/lib/src/harness.dart
+++ b/benchmark/lib/src/harness.dart
@@ -1,0 +1,545 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/physics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+
+/// Which cost to measure.
+enum BenchMode {
+  /// Time only inside the animation listener (notify + value read).
+  /// Simulation advance happens before notify; prefer [pump] for full tick cost.
+  tick,
+
+  /// Wall time of `tester.pump` + work (includes framework scheduling).
+  pump,
+
+  /// Record both [tick] and [pump] samples per run.
+  both,
+}
+
+/// Shared knobs for every scenario.
+class BenchConfig {
+  const BenchConfig({
+    this.warmupFrames = 60,
+    this.measuredFrames = 240,
+    this.frameStep = const Duration(milliseconds: 16),
+    this.repeats = 7,
+    this.mode = BenchMode.both,
+  });
+
+  /// Quick smoke configuration.
+  const BenchConfig.quick()
+      : warmupFrames = 15,
+        measuredFrames = 60,
+        frameStep = const Duration(milliseconds: 16),
+        repeats = 3,
+        mode = BenchMode.both;
+
+  final int warmupFrames;
+  final int measuredFrames;
+  final Duration frameStep;
+  final int repeats;
+  final BenchMode mode;
+
+  bool get measuresTick => mode == BenchMode.tick || mode == BenchMode.both;
+  bool get measuresPump => mode == BenchMode.pump || mode == BenchMode.both;
+
+  BenchConfig copyWith({
+    int? warmupFrames,
+    int? measuredFrames,
+    Duration? frameStep,
+    int? repeats,
+    BenchMode? mode,
+  }) {
+    return BenchConfig(
+      warmupFrames: warmupFrames ?? this.warmupFrames,
+      measuredFrames: measuredFrames ?? this.measuredFrames,
+      frameStep: frameStep ?? this.frameStep,
+      repeats: repeats ?? this.repeats,
+      mode: mode ?? this.mode,
+    );
+  }
+}
+
+/// One measured sample for one side and one layer.
+class SideSample {
+  const SideSample({
+    required this.side,
+    required this.layer,
+    required this.elapsed,
+    required this.frames,
+    required this.sink,
+  });
+
+  final String side;
+  final BenchMode layer;
+  final Duration elapsed;
+  final int frames;
+  final double sink;
+
+  double get microsPerFrame =>
+      frames == 0 ? 0 : elapsed.inMicroseconds / frames;
+
+  Map<String, Object?> toJson() => {
+        'side': side,
+        'layer': layer.name,
+        'elapsedMicros': elapsed.inMicroseconds,
+        'frames': frames,
+        'microsPerFrame': microsPerFrame,
+        'sink': sink,
+      };
+}
+
+/// Distribution over repeated [SideSample]s for one side/layer.
+class SideStats {
+  const SideStats({
+    required this.p50,
+    required this.p90,
+    required this.mean,
+    required this.stddev,
+    required this.n,
+  });
+
+  final double p50;
+  final double p90;
+  final double mean;
+  final double stddev;
+  final int n;
+
+  factory SideStats.from(List<SideSample> samples) {
+    assert(samples.isNotEmpty, 'SideStats requires samples');
+    final values = [
+      for (final s in samples) s.microsPerFrame,
+    ]..sort();
+    final n = values.length;
+    final mean = values.reduce((a, b) => a + b) / n;
+    final variance =
+        values.map((v) => (v - mean) * (v - mean)).reduce((a, b) => a + b) / n;
+    return SideStats(
+      p50: _percentile(values, 0.50),
+      p90: _percentile(values, 0.90),
+      mean: mean,
+      stddev: math.sqrt(variance),
+      n: n,
+    );
+  }
+
+  static double _percentile(List<double> sorted, double p) {
+    if (sorted.length == 1) return sorted.first;
+    final rank = p * (sorted.length - 1);
+    final lo = rank.floor();
+    final hi = rank.ceil();
+    if (lo == hi) return sorted[lo];
+    final t = rank - lo;
+    return sorted[lo] * (1 - t) + sorted[hi] * t;
+  }
+
+  Map<String, Object?> toJson() => {
+        'p50': p50,
+        'p90': p90,
+        'mean': mean,
+        'stddev': stddev,
+        'n': n,
+      };
+}
+
+/// Aggregated outcome for one scenario.
+class ScenarioResult {
+  const ScenarioResult({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.params,
+    required this.motor,
+    required this.flutter,
+    this.primaryLabel = 'Motor',
+    this.baselineLabel = 'Flutter',
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final Map<String, Object?> params;
+  final List<SideSample> motor;
+  final List<SideSample> flutter;
+  final String primaryLabel;
+  final String baselineLabel;
+
+  List<SideSample> motorLayer(BenchMode layer) =>
+      motor.where((s) => s.layer == layer).toList();
+
+  List<SideSample> flutterLayer(BenchMode layer) =>
+      flutter.where((s) => s.layer == layer).toList();
+
+  SideStats motorStats(BenchMode layer) => SideStats.from(motorLayer(layer));
+
+  SideStats flutterStats(BenchMode layer) =>
+      SideStats.from(flutterLayer(layer));
+
+  /// Positive => primary (Motor) slower.
+  double deltaPercent(BenchMode layer) {
+    final baseline = flutterStats(layer).p50;
+    if (baseline == 0) return 0;
+    return (motorStats(layer).p50 - baseline) / baseline * 100;
+  }
+
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'params': params,
+        'primaryLabel': primaryLabel,
+        'baselineLabel': baselineLabel,
+        'layers': {
+          for (final layer in {for (final s in [...motor, ...flutter]) s.layer})
+            layer.name: {
+              'primary': motorStats(layer).toJson(),
+              'baseline': flutterStats(layer).toJson(),
+              'deltaPercentP50': deltaPercent(layer),
+            },
+        },
+        'samples': {
+          'primary': [for (final s in motor) s.toJson()],
+          'baseline': [for (final s in flutter) s.toJson()],
+        },
+      };
+}
+
+/// Contract implemented by every benchmark scenario.
+abstract class BenchScenario {
+  String get id;
+  String get name;
+  String get description;
+  Map<String, Object?> get params => const {};
+
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config);
+}
+
+/// Measures animation work for [config.mode].
+///
+/// - `tick`: stopwatch only inside the animation listener while
+///   frames are pumped (notify + value read; sim advance is just before notify).
+/// - `pump`: wall clock around the measured pump loop.
+/// - Asserts [isAnimating] stays true through warmup and measure.
+Future<List<SideSample>> measureSide({
+  required WidgetTester tester,
+  required BenchConfig config,
+  required String side,
+  required Listenable listenable,
+  required void Function() start,
+  required double Function() read,
+  required void Function() dispose,
+  required bool Function() isAnimating,
+}) async {
+  var sink = 0.0;
+  var notifyCount = 0;
+  final tickSw = Stopwatch();
+  var accumulateTicks = false;
+
+  void listener() {
+    notifyCount++;
+    if (accumulateTicks) {
+      tickSw.start();
+      sink += read();
+      tickSw.stop();
+    } else {
+      sink += read();
+    }
+  }
+
+  listenable.addListener(listener);
+  start();
+  listener();
+
+  for (var i = 0; i < config.warmupFrames; i++) {
+    await tester.pump(config.frameStep);
+    expect(
+      isAnimating(),
+      isTrue,
+      reason: '$side stopped animating during warmup frame $i',
+    );
+  }
+
+  final notifiesBefore = notifyCount;
+  tickSw
+    ..stop()
+    ..reset();
+  accumulateTicks = config.measuresTick;
+
+  final pumpSw = Stopwatch();
+  if (config.measuresPump) pumpSw.start();
+
+  var stayedAnimating = true;
+  for (var i = 0; i < config.measuredFrames; i++) {
+    await tester.pump(config.frameStep);
+    if (!isAnimating()) stayedAnimating = false;
+  }
+
+  if (config.measuresPump) pumpSw.stop();
+  accumulateTicks = false;
+  listenable.removeListener(listener);
+
+  expect(
+    stayedAnimating,
+    isTrue,
+    reason: '$side stopped animating during measured window',
+  );
+  expect(
+    notifyCount,
+    greaterThan(notifiesBefore),
+    reason: '$side produced no animation notifications during measure',
+  );
+  expect(sink.isFinite, isTrue);
+
+  dispose();
+
+  return [
+    if (config.measuresTick)
+      SideSample(
+        side: side,
+        layer: BenchMode.tick,
+        elapsed: tickSw.elapsed,
+        frames: config.measuredFrames,
+        sink: sink,
+      ),
+    if (config.measuresPump)
+      SideSample(
+        side: side,
+        layer: BenchMode.pump,
+        elapsed: pumpSw.elapsed,
+        frames: config.measuredFrames,
+        sink: sink,
+      ),
+  ];
+}
+
+/// Times a pure synchronous loop (no ticker).
+SideSample measureSyncLoop({
+  required String side,
+  required int iterations,
+  required void Function(int i) body,
+  required double Function() read,
+}) {
+  var sink = 0.0;
+  final warmup = math.max(1, iterations ~/ 10);
+  for (var i = 0; i < warmup; i++) {
+    body(i);
+    sink += read();
+  }
+
+  final sinkBefore = sink;
+  final sw = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    body(i);
+    sink += read();
+  }
+  sw.stop();
+
+  expect(sink.isFinite, isTrue);
+  expect(sink, isNot(equals(sinkBefore)));
+  return SideSample(
+    side: side,
+    layer: BenchMode.tick,
+    elapsed: sw.elapsed,
+    frames: iterations,
+    sink: sink,
+  );
+}
+
+/// Runs both sides [BenchConfig.repeats] times, alternating order.
+Future<ScenarioResult> runPaired({
+  required WidgetTester tester,
+  required BenchConfig config,
+  required BenchScenario scenario,
+  required Future<List<SideSample>> Function() motorOnce,
+  required Future<List<SideSample>> Function() flutterOnce,
+  String primaryLabel = 'Motor',
+  String baselineLabel = 'Flutter',
+}) async {
+  final motor = <SideSample>[];
+  final flutter = <SideSample>[];
+
+  for (var i = 0; i < config.repeats; i++) {
+    if (i.isEven) {
+      motor.addAll(await motorOnce());
+      flutter.addAll(await flutterOnce());
+    } else {
+      flutter.addAll(await flutterOnce());
+      motor.addAll(await motorOnce());
+    }
+  }
+
+  return ScenarioResult(
+    id: scenario.id,
+    name: scenario.name,
+    description: scenario.description,
+    params: scenario.params,
+    motor: motor,
+    flutter: flutter,
+    primaryLabel: primaryLabel,
+    baselineLabel: baselineLabel,
+  );
+}
+
+/// Pretty-prints results as markdown tables (one per measured layer).
+void printResults(List<ScenarioResult> results, BenchConfig config) {
+  if (results.isEmpty) {
+    // ignore: avoid_print
+    print('No benchmark results.');
+    return;
+  }
+
+  final layers = <BenchMode>[
+    if (config.measuresTick) BenchMode.tick,
+    if (config.measuresPump) BenchMode.pump,
+  ];
+
+  final buf = StringBuffer()..writeln();
+
+  for (final layer in layers) {
+    buf
+      ..writeln('## Motor vs AnimationController — `${layer.name}` layer')
+      ..writeln()
+      ..writeln(
+        '| Scenario | Params | ${results.first.baselineLabel} p50 | '
+        '${results.first.primaryLabel} p50 | Δ p50 | p90 Δ |',
+      )
+      ..writeln('|---|---|---:|---:|---:|---:|');
+
+    for (final r in results) {
+      if (r.motorLayer(layer).isEmpty) continue;
+      final params =
+          r.params.entries.map((e) => '${e.key}=${e.value}').join(', ');
+      final delta = r.deltaPercent(layer);
+      final sign = delta > 0 ? '+' : '';
+      final base = r.flutterStats(layer);
+      final prim = r.motorStats(layer);
+      final p90Delta = base.p90 == 0
+          ? 0.0
+          : (prim.p90 - base.p90) / base.p90 * 100;
+      final p90Sign = p90Delta > 0 ? '+' : '';
+      buf.writeln(
+        '| ${r.name} | $params | '
+        '${base.p50.toStringAsFixed(1)} | '
+        '${prim.p50.toStringAsFixed(1)} | '
+        '$sign${delta.toStringAsFixed(1)}% | '
+        '$p90Sign${p90Delta.toStringAsFixed(1)}% |',
+      );
+    }
+
+    buf
+      ..writeln()
+      ..writeln(
+        '_µs/frame (or µs/op for sync). Positive Δ = ${results.first.primaryLabel} '
+        'slower. p50/p90 over ${results.first.motorLayer(layer).length} runs. '
+        '`${layer.name}`: ${switch (layer) {
+          BenchMode.tick => 'listener notify + value read only',
+          BenchMode.pump => 'full tester.pump wall time',
+          BenchMode.both => '',
+        }}_',
+      )
+      ..writeln();
+  }
+
+  // ignore: avoid_print
+  print(buf);
+}
+
+/// Writes [results] as JSON. Returns the path written.
+File writeResultsJson(
+  List<ScenarioResult> results,
+  BenchConfig config, {
+  String? path,
+}) {
+  final relative = path ??
+      'results/bench_${DateTime.now().millisecondsSinceEpoch}.json';
+  final file = File(relative);
+  file.parent.createSync(recursive: true);
+  final payload = <String, Object?>{
+    'generatedAt': DateTime.now().toIso8601String(),
+    'config': <String, Object?>{
+      'warmupFrames': config.warmupFrames,
+      'measuredFrames': config.measuredFrames,
+      'frameStepMs': config.frameStep.inMilliseconds,
+      'repeats': config.repeats,
+      'mode': config.mode.name,
+    },
+    'results': [
+      for (final r in results) r.toJson(),
+    ],
+  };
+  final encoded = const JsonEncoder.withIndent('  ').convert(payload);
+  file.writeAsStringSync(encoded);
+  File('${file.parent.path}/latest.json').writeAsStringSync(encoded);
+  return file;
+}
+
+double hashDoubles(Iterable<double> values) {
+  var acc = 0.0;
+  var i = 0;
+  for (final v in values) {
+    acc += v * (1 + (i++ % 7));
+  }
+  return math.sin(acc);
+}
+
+/// Status-driven spring ping-pong for [AnimationController] (matches Motor).
+VoidCallback attachFlutterSpringPingPong(
+  AnimationController controller,
+  SpringDescription description, {
+  double low = 0,
+  double high = 1,
+}) {
+  var target = high;
+  void kick() {
+    controller.animateWith(
+      SpringSimulation(
+        description,
+        controller.value,
+        target,
+        controller.velocity,
+      ),
+    );
+  }
+
+  void onStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    target = target == low ? high : low;
+    kick();
+  }
+
+  controller.addStatusListener(onStatus);
+  kick();
+  return () => controller.removeStatusListener(onStatus);
+}
+
+/// Status-driven spring ping-pong for [MotionController] (matches Flutter).
+///
+/// Motor reports [AnimationStatus.dismissed] when settling at the controller's
+/// initial value and [AnimationStatus.completed] otherwise — so both must
+/// retarget, or long windows (full suite) stop after the first return trip.
+VoidCallback attachMotorSpringPingPong<T extends Object>(
+  MotionController<T> controller, {
+  required T low,
+  required T high,
+}) {
+  var target = high;
+  void kick() => controller.animateTo(target);
+
+  void onStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed &&
+        status != AnimationStatus.dismissed) {
+      return;
+    }
+    target = target == low ? high : low;
+    kick();
+  }
+
+  controller.addStatusListener(onStatus);
+  kick();
+  return () => controller.removeStatusListener(onStatus);
+}

--- a/benchmark/lib/src/scenarios/interrupt_retarget.dart
+++ b/benchmark/lib/src/scenarios/interrupt_retarget.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:flutter/animation.dart';
+import 'package:flutter/physics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// Mid-flight retargeting cost (setup + following frame work).
+class InterruptRetargetScenario implements BenchScenario {
+  const InterruptRetargetScenario({this.retargets = 60});
+
+  final int retargets;
+
+  static const _motion = CupertinoMotion.smooth();
+
+  @override
+  String get id => 'interrupt_retarget';
+
+  @override
+  String get name => 'Interrupt / retarget';
+
+  @override
+  String get description =>
+      'Re-target a spring $retargets times (Motor animateTo vs AC animateWith).';
+
+  @override
+  Map<String, Object?> get params => {'retargets': retargets};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    final description = _motion.description;
+
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () => _runMotor(tester, config),
+      flutterOnce: () => _runFlutter(tester, config, description),
+    );
+  }
+
+  Future<List<SideSample>> _runMotor(
+    WidgetTester tester,
+    BenchConfig config,
+  ) async {
+    final c = SingleMotionController(
+      motion: _motion,
+      vsync: tester,
+      velocityTracking: const VelocityTracking.off(),
+    );
+    var sink = 0.0;
+    unawaited(c.animateTo(1.0));
+
+    for (var i = 0; i < config.warmupFrames; i++) {
+      await tester.pump(config.frameStep);
+      sink += c.value;
+    }
+
+    final tickSw = Stopwatch();
+    final pumpSw = Stopwatch();
+
+    for (var i = 0; i < retargets; i++) {
+      if (config.measuresPump) pumpSw.start();
+      if (config.measuresTick) tickSw.start();
+      unawaited(c.animateTo(i.isEven ? 1.0 : 0.0));
+      if (config.measuresTick) {
+        sink += c.value;
+        tickSw.stop();
+      }
+      await tester.pump(config.frameStep);
+      if (!config.measuresTick) sink += c.value;
+      if (config.measuresPump) pumpSw.stop();
+    }
+
+    expect(sink.isFinite, isTrue);
+    c.dispose();
+    return _samples('motor', config, tickSw, pumpSw, sink);
+  }
+
+  Future<List<SideSample>> _runFlutter(
+    WidgetTester tester,
+    BenchConfig config,
+    SpringDescription description,
+  ) async {
+    final c = AnimationController.unbounded(vsync: tester);
+    var sink = 0.0;
+    unawaited(c.animateWith(SpringSimulation(description, 0, 1, 0)));
+
+    for (var i = 0; i < config.warmupFrames; i++) {
+      await tester.pump(config.frameStep);
+      sink += c.value;
+    }
+
+    final tickSw = Stopwatch();
+    final pumpSw = Stopwatch();
+
+    for (var i = 0; i < retargets; i++) {
+      final target = i.isEven ? 1.0 : 0.0;
+      if (config.measuresPump) pumpSw.start();
+      if (config.measuresTick) tickSw.start();
+      unawaited(
+        c.animateWith(
+          SpringSimulation(description, c.value, target, c.velocity),
+        ),
+      );
+      if (config.measuresTick) {
+        sink += c.value;
+        tickSw.stop();
+      }
+      await tester.pump(config.frameStep);
+      if (!config.measuresTick) sink += c.value;
+      if (config.measuresPump) pumpSw.stop();
+    }
+
+    expect(sink.isFinite, isTrue);
+    c.dispose();
+    return _samples('flutter', config, tickSw, pumpSw, sink);
+  }
+
+  List<SideSample> _samples(
+    String side,
+    BenchConfig config,
+    Stopwatch tickSw,
+    Stopwatch pumpSw,
+    double sink,
+  ) {
+    return [
+      if (config.measuresTick)
+        SideSample(
+          side: side,
+          layer: BenchMode.tick,
+          elapsed: tickSw.elapsed,
+          frames: retargets,
+          sink: sink,
+        ),
+      if (config.measuresPump)
+        SideSample(
+          side: side,
+          layer: BenchMode.pump,
+          elapsed: pumpSw.elapsed,
+          frames: retargets,
+          sink: sink,
+        ),
+    ];
+  }
+}

--- a/benchmark/lib/src/scenarios/manual_set.dart
+++ b/benchmark/lib/src/scenarios/manual_set.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// Synchronous writes: Motor `set` (velocity off) vs `AnimationController.value=`.
+class ManualSetScenario implements BenchScenario {
+  const ManualSetScenario({this.iterations = 8000});
+
+  final int iterations;
+
+  @override
+  String get id => 'manual_set';
+
+  @override
+  String get name => 'Manual set';
+
+  @override
+  String get description =>
+      'TrackController.set (velocity off) vs AnimationController.value=.';
+
+  @override
+  Map<String, Object?> get params => {
+        'iterations': iterations,
+        'velocityTracking': false,
+      };
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) async {
+    final track = Track<double>(
+      const SingleMotionConverter(),
+      initial: 0.0,
+      debugLabel: 'set',
+    );
+
+    final motor = <SideSample>[];
+    final flutter = <SideSample>[];
+
+    for (var r = 0; r < config.repeats; r++) {
+      SideSample motorOnce() {
+        final c = TrackController(
+          vsync: tester,
+          velocityTracking: const VelocityTracking.off(),
+        )..set([track.value(0.0)]);
+        final sample = measureSyncLoop(
+          side: 'motor',
+          iterations: iterations,
+          body: (i) => c.set([track.value(i / iterations)]),
+          read: () => c.value<double>(track),
+        );
+        c.dispose();
+        return sample;
+      }
+
+      SideSample flutterOnce() {
+        final c = AnimationController.unbounded(vsync: tester);
+        final sample = measureSyncLoop(
+          side: 'flutter',
+          iterations: iterations,
+          body: (i) => c.value = i / iterations,
+          read: () => c.value,
+        );
+        c.dispose();
+        return sample;
+      }
+
+      if (r.isEven) {
+        motor.add(motorOnce());
+        flutter.add(flutterOnce());
+      } else {
+        flutter.add(flutterOnce());
+        motor.add(motorOnce());
+      }
+    }
+
+    return ScenarioResult(
+      id: id,
+      name: name,
+      description: description,
+      params: params,
+      motor: motor,
+      flutter: flutter,
+    );
+  }
+}
+
+/// Motor-only: cost of [VelocityTracking.on] vs off on `set`.
+class VelocityTrackingOverheadScenario implements BenchScenario {
+  const VelocityTrackingOverheadScenario({this.iterations = 8000});
+
+  final int iterations;
+
+  @override
+  String get id => 'velocity_tracking_overhead';
+
+  @override
+  String get name => 'Velocity tracking overhead';
+
+  @override
+  String get description =>
+      'Motor TrackController.set with VelocityTracking.on vs off.';
+
+  @override
+  Map<String, Object?> get params => {'iterations': iterations};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) async {
+    final track = Track<double>(
+      const SingleMotionConverter(),
+      initial: 0.0,
+      debugLabel: 'vt',
+    );
+
+    final onSamples = <SideSample>[];
+    final offSamples = <SideSample>[];
+
+    SideSample once({required bool tracking}) {
+      final c = TrackController(
+        vsync: tester,
+        velocityTracking: tracking
+            ? const VelocityTracking.on()
+            : const VelocityTracking.off(),
+      )..set([track.value(0.0)]);
+      final sample = measureSyncLoop(
+        side: tracking ? 'on' : 'off',
+        iterations: iterations,
+        body: (i) => c.set([track.value(i / iterations)]),
+        read: () => c.value<double>(track),
+      );
+      c.dispose();
+      return sample;
+    }
+
+    for (var r = 0; r < config.repeats; r++) {
+      if (r.isEven) {
+        onSamples.add(once(tracking: true));
+        offSamples.add(once(tracking: false));
+      } else {
+        offSamples.add(once(tracking: false));
+        onSamples.add(once(tracking: true));
+      }
+    }
+
+    return ScenarioResult(
+      id: id,
+      name: name,
+      description: description,
+      params: params,
+      motor: onSamples,
+      flutter: offSamples,
+      primaryLabel: 'tracking on',
+      baselineLabel: 'tracking off',
+    );
+  }
+}

--- a/benchmark/lib/src/scenarios/multi_track_scale.dart
+++ b/benchmark/lib/src/scenarios/multi_track_scale.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// N properties on one [TrackController] vs N [AnimationController]s.
+class MultiTrackScaleScenario implements BenchScenario {
+  const MultiTrackScaleScenario(this.trackCount);
+
+  final int trackCount;
+
+  static const _duration = Duration(milliseconds: 800);
+  static const _motion = CurvedMotion(_duration, Curves.easeInOut);
+
+  @override
+  String get id => 'multi_track_$trackCount';
+
+  @override
+  String get name => 'Multi-track scale';
+
+  @override
+  String get description =>
+      '$trackCount tracks / 1 ticker vs $trackCount AnimationControllers.';
+
+  @override
+  Map<String, Object?> get params => {'tracks': trackCount};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () async {
+        final tracks = List<Track<double>>.generate(
+          trackCount,
+          (i) => Track(
+            const SingleMotionConverter(),
+            initial: 0.0,
+            motion: _motion,
+            debugLabel: 't$i',
+          ),
+        );
+        final c = TrackController(
+          vsync: tester,
+          velocityTracking: const VelocityTracking.off(),
+        );
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'motor',
+          listenable: c,
+          start: () {
+            c.animate(
+              [
+                for (final track in tracks)
+                  track([
+                    const TrackStep.to(1.0),
+                    const TrackStep.to(0.0),
+                  ]),
+              ],
+              loop: LoopMode.loop,
+            );
+          },
+          read: () => hashDoubles([
+            for (final track in tracks) c.value(track),
+          ]),
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            c.stop(canceled: true);
+            c.dispose();
+          },
+        );
+      },
+      flutterOnce: () async {
+        final controllers = List<AnimationController>.generate(
+          trackCount,
+          (_) => AnimationController(vsync: tester, duration: _duration),
+        );
+        // Listen to the last controller so earlier tickers have already
+        // advanced this frame before we sample all values once.
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'flutter',
+          listenable: controllers.last,
+          start: () {
+            for (final c in controllers) {
+              c.repeat(reverse: true);
+            }
+          },
+          read: () => hashDoubles([
+            for (final c in controllers) c.value,
+          ]),
+          isAnimating: () => controllers.any((c) => c.isAnimating),
+          dispose: () {
+            for (final c in controllers) {
+              c
+                ..stop()
+                ..dispose();
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/benchmark/lib/src/scenarios/offset_spring.dart
+++ b/benchmark/lib/src/scenarios/offset_spring.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// 2D spring: one [MotionController]<[Offset]> vs two [AnimationController]s.
+class OffsetSpringScenario implements BenchScenario {
+  const OffsetSpringScenario();
+
+  static const _motion = CupertinoMotion.smooth();
+  static const _target = Offset(120, 80);
+
+  @override
+  String get id => 'offset_spring';
+
+  @override
+  String get name => 'Offset spring (2D)';
+
+  @override
+  String get description =>
+      'Status-driven Offset spring vs 2× AnimationController.';
+
+  @override
+  Map<String, Object?> get params => const {'dims': 2, 'motion': 'spring'};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    final description = _motion.description;
+
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () async {
+        final c = MotionController<Offset>(
+          motion: _motion,
+          vsync: tester,
+          converter: const OffsetMotionConverter(),
+          initialValue: Offset.zero,
+          velocityTracking: const VelocityTracking.off(),
+        );
+        late final VoidCallback detach;
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'motor',
+          listenable: c,
+          start: () {
+            detach = attachMotorSpringPingPong(
+              c,
+              low: Offset.zero,
+              high: _target,
+            );
+          },
+          read: () => c.value.dx + c.value.dy,
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            detach();
+            c.stop(canceled: true);
+            c.dispose();
+          },
+        );
+      },
+      flutterOnce: () async {
+        final x = AnimationController.unbounded(vsync: tester);
+        final y = AnimationController.unbounded(vsync: tester);
+        late final VoidCallback detachX;
+        late final VoidCallback detachY;
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'flutter',
+          listenable: y,
+          start: () {
+            detachX = attachFlutterSpringPingPong(
+              x,
+              description,
+              high: _target.dx,
+            );
+            detachY = attachFlutterSpringPingPong(
+              y,
+              description,
+              high: _target.dy,
+            );
+          },
+          read: () => x.value + y.value,
+          isAnimating: () => x.isAnimating || y.isAnimating,
+          dispose: () {
+            detachX();
+            detachY();
+            x
+              ..stop()
+              ..dispose();
+            y
+              ..stop()
+              ..dispose();
+          },
+        );
+      },
+    );
+  }
+}

--- a/benchmark/lib/src/scenarios/single_curve.dart
+++ b/benchmark/lib/src/scenarios/single_curve.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// 1D duration/curve: Motor [TrackController] vs [AnimationController].
+class SingleCurveScenario implements BenchScenario {
+  const SingleCurveScenario();
+
+  static const _duration = Duration(milliseconds: 800);
+  static const _motion = CurvedMotion(_duration, Curves.easeInOut);
+
+  @override
+  String get id => 'single_curve';
+
+  @override
+  String get name => 'Single curve (1D)';
+
+  @override
+  String get description =>
+      'CurvedMotion vs AnimationController — looping easeInOut.';
+
+  @override
+  Map<String, Object?> get params => const {'dims': 1, 'motion': 'curve'};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () async {
+        final track = Track<double>(
+          const SingleMotionConverter(),
+          initial: 0.0,
+          motion: _motion,
+        );
+        final c = TrackController(
+          vsync: tester,
+          velocityTracking: const VelocityTracking.off(),
+        );
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'motor',
+          listenable: c,
+          start: () {
+            c.animate(
+              [
+                track([
+                  const TrackStep.to(1.0),
+                  const TrackStep.to(0.0),
+                ]),
+              ],
+              loop: LoopMode.loop,
+            );
+          },
+          read: () => c.value(track),
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            c.stop(canceled: true);
+            c.dispose();
+          },
+        );
+      },
+      flutterOnce: () async {
+        final c = AnimationController(
+          vsync: tester,
+          duration: _duration,
+        );
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'flutter',
+          listenable: c,
+          start: () => c.repeat(reverse: true),
+          read: () => c.value,
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            c
+              ..stop()
+              ..dispose();
+          },
+        );
+      },
+    );
+  }
+}

--- a/benchmark/lib/src/scenarios/single_spring.dart
+++ b/benchmark/lib/src/scenarios/single_spring.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// 1D spring with matching status-driven ping-pong on both sides.
+class SingleSpringScenario implements BenchScenario {
+  const SingleSpringScenario();
+
+  static const _motion = CupertinoMotion.smooth();
+
+  @override
+  String get id => 'single_spring';
+
+  @override
+  String get name => 'Single spring (1D)';
+
+  @override
+  String get description =>
+      'Status-driven spring ping-pong (Motor animateTo vs AC animateWith).';
+
+  @override
+  Map<String, Object?> get params => const {'dims': 1, 'motion': 'spring'};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    final description = _motion.description;
+
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () async {
+        final c = SingleMotionController(
+          motion: _motion,
+          vsync: tester,
+          velocityTracking: const VelocityTracking.off(),
+        );
+        late final VoidCallback detach;
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'motor',
+          listenable: c,
+          start: () {
+            detach = attachMotorSpringPingPong(c, low: 0.0, high: 1.0);
+          },
+          read: () => c.value,
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            detach();
+            c.stop(canceled: true);
+            c.dispose();
+          },
+        );
+      },
+      flutterOnce: () async {
+        final c = AnimationController.unbounded(vsync: tester);
+        late final VoidCallback detach;
+        return measureSide(
+          tester: tester,
+          config: config,
+          side: 'flutter',
+          listenable: c,
+          start: () {
+            detach = attachFlutterSpringPingPong(c, description);
+          },
+          read: () => c.value,
+          isAnimating: () => c.isAnimating,
+          dispose: () {
+            detach();
+            c
+              ..stop()
+              ..dispose();
+          },
+        );
+      },
+    );
+  }
+}

--- a/benchmark/lib/src/scenarios/widget_rebuild.dart
+++ b/benchmark/lib/src/scenarios/widget_rebuild.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor/motor.dart';
+import 'package:motor_benchmark/src/harness.dart';
+
+/// Widget rebuild path: looping [TrackBuilder] vs [AnimatedBuilder].
+class WidgetRebuildScenario implements BenchScenario {
+  const WidgetRebuildScenario();
+
+  static const _duration = Duration(milliseconds: 800);
+
+  @override
+  String get id => 'widget_rebuild';
+
+  @override
+  String get name => 'Widget rebuild';
+
+  @override
+  String get description =>
+      'TrackBuilder vs AnimatedBuilder rebuilding Transform + child.';
+
+  @override
+  Map<String, Object?> get params => const {'widget': true};
+
+  @override
+  Future<ScenarioResult> run(WidgetTester tester, BenchConfig config) {
+    return runPaired(
+      tester: tester,
+      config: config,
+      scenario: this,
+      motorOnce: () => _runMotor(tester, config),
+      flutterOnce: () => _runFlutter(tester, config),
+    );
+  }
+
+  Future<List<SideSample>> _runMotor(
+    WidgetTester tester,
+    BenchConfig config,
+  ) async {
+    var sink = 0.0;
+    final tickSw = Stopwatch();
+    var measuringTicks = false;
+    final opacity = Track(
+      const SingleMotionConverter(),
+      initial: 0.0,
+      motion: const CurvedMotion(_duration, Curves.easeInOut),
+      debugLabel: 'opacity',
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TrackBuilder(
+          animations: [
+            opacity([
+              const TrackStep.to(1.0),
+              const TrackStep.to(0.0),
+            ]),
+          ],
+          loop: LoopMode.loop,
+          builder: (context, value, child) {
+            final v = value(opacity);
+            if (measuringTicks) {
+              tickSw.start();
+              sink += v;
+              tickSw.stop();
+            } else {
+              sink += v;
+            }
+            return Transform.translate(
+              offset: Offset(v * 100, 0),
+              child: child,
+            );
+          },
+          child: const _Leaf(),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < config.warmupFrames; i++) {
+      await tester.pump(config.frameStep);
+    }
+
+    tickSw
+      ..stop()
+      ..reset();
+    measuringTicks = config.measuresTick;
+    final pumpSw = Stopwatch();
+    if (config.measuresPump) pumpSw.start();
+
+    for (var i = 0; i < config.measuredFrames; i++) {
+      await tester.pump(config.frameStep);
+    }
+
+    if (config.measuresPump) pumpSw.stop();
+    measuringTicks = false;
+    expect(sink.isFinite, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    return [
+      if (config.measuresTick)
+        SideSample(
+          side: 'motor',
+          layer: BenchMode.tick,
+          elapsed: tickSw.elapsed,
+          frames: config.measuredFrames,
+          sink: sink,
+        ),
+      if (config.measuresPump)
+        SideSample(
+          side: 'motor',
+          layer: BenchMode.pump,
+          elapsed: pumpSw.elapsed,
+          frames: config.measuredFrames,
+          sink: sink,
+        ),
+    ];
+  }
+
+  Future<List<SideSample>> _runFlutter(
+    WidgetTester tester,
+    BenchConfig config,
+  ) async {
+    var sink = 0.0;
+    final tickSw = Stopwatch();
+    var measuringTicks = false;
+    late final AnimationController controller;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: _FlutterAnimHost(
+          duration: _duration,
+          onTick: (value) {
+            if (measuringTicks) {
+              tickSw.start();
+              sink += value;
+              tickSw.stop();
+            } else {
+              sink += value;
+            }
+          },
+          onCreated: (c) => controller = c,
+          child: const _Leaf(),
+        ),
+      ),
+    );
+    controller.repeat(reverse: true);
+
+    for (var i = 0; i < config.warmupFrames; i++) {
+      await tester.pump(config.frameStep);
+    }
+
+    tickSw
+      ..stop()
+      ..reset();
+    measuringTicks = config.measuresTick;
+    final pumpSw = Stopwatch();
+    if (config.measuresPump) pumpSw.start();
+
+    for (var i = 0; i < config.measuredFrames; i++) {
+      await tester.pump(config.frameStep);
+    }
+
+    if (config.measuresPump) pumpSw.stop();
+    measuringTicks = false;
+    expect(sink.isFinite, isTrue);
+    expect(controller.isAnimating, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    return [
+      if (config.measuresTick)
+        SideSample(
+          side: 'flutter',
+          layer: BenchMode.tick,
+          elapsed: tickSw.elapsed,
+          frames: config.measuredFrames,
+          sink: sink,
+        ),
+      if (config.measuresPump)
+        SideSample(
+          side: 'flutter',
+          layer: BenchMode.pump,
+          elapsed: pumpSw.elapsed,
+          frames: config.measuredFrames,
+          sink: sink,
+        ),
+    ];
+  }
+}
+
+class _Leaf extends StatelessWidget {
+  const _Leaf();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: 48,
+      height: 48,
+      child: ColoredBox(color: Color(0xFF2244AA)),
+    );
+  }
+}
+
+class _FlutterAnimHost extends StatefulWidget {
+  const _FlutterAnimHost({
+    required this.duration,
+    required this.onTick,
+    required this.onCreated,
+    required this.child,
+  });
+
+  final Duration duration;
+  final ValueChanged<double> onTick;
+  final ValueChanged<AnimationController> onCreated;
+  final Widget child;
+
+  @override
+  State<_FlutterAnimHost> createState() => _FlutterAnimHostState();
+}
+
+class _FlutterAnimHostState extends State<_FlutterAnimHost>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+    widget.onCreated(_controller);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      child: widget.child,
+      builder: (context, child) {
+        widget.onTick(_animation.value);
+        return Transform.translate(
+          offset: Offset(_animation.value * 100, 0),
+          child: child,
+        );
+      },
+    );
+  }
+}

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -1,0 +1,20 @@
+name: motor_benchmark
+description: Microbenchmarks comparing Motor to Flutter's AnimationController.
+publish_to: none
+resolution: workspace
+version: 0.0.1
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.32.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  motor:
+    path: ../packages/motor
+
+dev_dependencies:
+  lintervention: ^0.3.1

--- a/benchmark/test/run_benchmarks_test.dart
+++ b/benchmark/test/run_benchmarks_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motor_benchmark/motor_benchmark.dart';
+
+/// Runs the Motor vs AnimationController microbenchmark suite.
+///
+/// ```sh
+/// cd benchmark
+/// flutter test --profile test/run_benchmarks_test.dart --reporter expanded
+///
+/// BENCH_MODE=tick|pump|both
+/// BENCH_FILTER=single_curve,multi_track
+/// BENCH_QUICK=1
+/// BENCH_JSON=results/run.json
+/// ```
+void main() {
+  final filter = Platform.environment['BENCH_FILTER'];
+  final quick = Platform.environment['BENCH_QUICK'] == '1';
+  final mode = parseBenchMode(Platform.environment['BENCH_MODE']);
+  final jsonPath = Platform.environment['BENCH_JSON'];
+
+  final config = (quick ? const BenchConfig.quick() : const BenchConfig())
+      .copyWith(mode: mode);
+
+  final scenarios = scenariosMatching(filter);
+  assert(
+    scenarios.isNotEmpty,
+    'No scenarios matched BENCH_FILTER=$filter. '
+    'Known ids: ${allScenarios().map((s) => s.id).join(', ')}',
+  );
+
+  testWidgets(
+    'Motor vs AnimationController benchmarks',
+    (tester) async {
+      final results = <ScenarioResult>[];
+      for (final scenario in scenarios) {
+        // ignore: avoid_print
+        print('→ ${scenario.id}: ${scenario.description}');
+        results.add(await scenario.run(tester, config));
+      }
+      printResults(results, config);
+
+      final file = writeResultsJson(results, config, path: jsonPath);
+      // ignore: avoid_print
+      print('Wrote ${file.path}');
+
+      for (final result in results) {
+        for (final layer in [
+          if (config.measuresTick) BenchMode.tick,
+          if (config.measuresPump) BenchMode.pump,
+        ]) {
+          if (result.motorLayer(layer).isEmpty) continue;
+          expect(result.motorStats(layer).p50, greaterThan(0));
+          expect(result.flutterStats(layer).p50, greaterThan(0));
+        }
+      }
+    },
+    timeout: Timeout(Duration(minutes: quick ? 3 : 20)),
+  );
+}

--- a/packages/motor/lib/src/controllers/_track_slot.dart
+++ b/packages/motor/lib/src/controllers/_track_slot.dart
@@ -6,26 +6,35 @@ class _TrackSlot<T extends Object> {
     required T initialValue,
     this.fallbackMotion,
     this.fallbackMotionPerDimension,
-  })  : _currentValues = converter.normalize(initialValue),
-        _velocityValues = List<double>.filled(
-          converter.normalize(initialValue).length,
-          0,
-        );
+  }) : _cachedValue = initialValue {
+    final normalized = converter.normalize(initialValue);
+    _currentValues = normalized;
+    _velocityValues = List<double>.filled(normalized.length, 0);
+    _cachedVelocity = converter.denormalize(_velocityValues);
+  }
 
   final MotionConverter<T> converter;
   final Motion? fallbackMotion;
   final List<Motion>? fallbackMotionPerDimension;
 
-  List<double> _currentValues;
-  List<double> _velocityValues;
+  late List<double> _currentValues;
+  late List<double> _velocityValues;
+  late T _cachedValue;
+  late T _cachedVelocity;
   StepPlayback<T>? _stepPlayback;
   _TrackSlotPlayback _playback = _TrackSlotPlayback.idle;
   Duration _startOffset = Duration.zero;
   Duration _inspectionStartOffset = Duration.zero;
 
-  T get value => converter.denormalize(_currentValues);
+  /// True while [_currentValues] / [_velocityValues] alias [StepPlayback]
+  /// buffers. Cleared on [stop] / [setValue] so the slot keeps a private copy.
+  var _borrowingPlaybackBuffers = false;
 
-  T get velocity => converter.denormalize(_velocityValues);
+  /// Eager denormalized value — refreshed after each sample, not on every read.
+  T get value => _cachedValue;
+
+  /// Eager denormalized velocity — refreshed after each sample.
+  T get velocity => _cachedVelocity;
 
   bool get isAnimating => _playback != _TrackSlotPlayback.idle;
 
@@ -43,17 +52,29 @@ class _TrackSlot<T extends Object> {
       _stepPlayback?.hasPassedSync(token) ?? false;
 
   void setValue(T value) {
+    _detachPlaybackBuffers();
     _currentValues = converter.normalize(value);
     _velocityValues = List<double>.filled(_currentValues.length, 0);
+    _cachedValue = value;
+    _cachedVelocity = converter.denormalize(_velocityValues);
     _stepPlayback = null;
     _playback = _TrackSlotPlayback.idle;
   }
 
   void setValueWithVelocity(T value, T velocity) {
+    _detachPlaybackBuffers();
     _currentValues = converter.normalize(value);
     _velocityValues = converter.normalize(velocity);
+    _cachedValue = value;
+    _cachedVelocity = velocity;
     _stepPlayback = null;
     _playback = _TrackSlotPlayback.idle;
+  }
+
+  /// Updates velocity buffers from an external estimate (e.g. gesture tracking).
+  void setVelocity(T velocity) {
+    _velocityValues = converter.normalize(velocity);
+    _cachedVelocity = velocity;
   }
 
   void play(
@@ -76,9 +97,13 @@ class _TrackSlot<T extends Object> {
       fallbackMotionPerDimension: fallbackMotionPerDimension,
       estimateDurations: estimateDurations,
     );
-    _currentValues = List.of(_stepPlayback!.values);
-    _velocityValues = List.of(_stepPlayback!.velocities);
+    // Zero-copy: read through the playback buffers mutated in place each tick.
+    final buffers = _stepPlayback!.borrowStateBuffers();
+    _currentValues = buffers.$1;
+    _velocityValues = buffers.$2;
+    _borrowingPlaybackBuffers = true;
     _playback = _TrackSlotPlayback.chained;
+    _refreshCaches();
   }
 
   double _localSeconds(Duration elapsed) {
@@ -102,6 +127,7 @@ class _TrackSlot<T extends Object> {
       _TrackSlotPlayback.chained => _tickStepPlayback(seconds),
     };
 
+    _refreshCaches();
     if (done) {
       _playback = _TrackSlotPlayback.idle;
     }
@@ -115,10 +141,12 @@ class _TrackSlot<T extends Object> {
     }
 
     final seconds = _inspectionSeconds(elapsed);
-    return switch (_playback) {
+    final done = switch (_playback) {
       _TrackSlotPlayback.idle => true,
       _TrackSlotPlayback.chained => _seekStepPlayback(seconds),
     };
+    _refreshCaches();
+    return done;
   }
 
   /// Re-bases the controller axis around this slot's current local playhead.
@@ -134,19 +162,12 @@ class _TrackSlot<T extends Object> {
   }
 
   bool _tickStepPlayback(double seconds) {
-    final playback = _stepPlayback!;
-    final done = playback.advanceTo(seconds);
-    _currentValues = List.of(playback.values);
-    _velocityValues = List.of(playback.velocities);
-    return done;
+    // Buffers are aliased; advanceTo samples in place — no List.of.
+    return _stepPlayback!.advanceTo(seconds);
   }
 
   bool _seekStepPlayback(double seconds) {
-    final playback = _stepPlayback!;
-    final done = playback.seekTo(seconds);
-    _currentValues = List.of(playback.values);
-    _velocityValues = List.of(playback.velocities);
-    return done;
+    return _stepPlayback!.seekTo(seconds);
   }
 
   /// Redirects this slot to settle at its current value using the fallback
@@ -172,9 +193,26 @@ class _TrackSlot<T extends Object> {
   }
 
   void stop({bool canceled = false}) {
+    _detachPlaybackBuffers();
+    for (var i = 0; i < _velocityValues.length; i++) {
+      _velocityValues[i] = 0;
+    }
+    _cachedVelocity = converter.denormalize(_velocityValues);
     _stepPlayback = null;
-    _velocityValues = List<double>.filled(_currentValues.length, 0);
     _playback = _TrackSlotPlayback.idle;
+  }
+
+  /// Takes ownership of the current buffers so [StepPlayback] can be dropped.
+  void _detachPlaybackBuffers() {
+    if (!_borrowingPlaybackBuffers) return;
+    _currentValues = List<double>.of(_currentValues, growable: false);
+    _velocityValues = List<double>.of(_velocityValues, growable: false);
+    _borrowingPlaybackBuffers = false;
+  }
+
+  void _refreshCaches() {
+    _cachedValue = converter.denormalize(_currentValues);
+    _cachedVelocity = converter.denormalize(_velocityValues);
   }
 
   int get currentStepIndex => _stepPlayback?.currentStepIndex ?? -1;

--- a/packages/motor/lib/src/controllers/motion_controller.dart
+++ b/packages/motor/lib/src/controllers/motion_controller.dart
@@ -109,7 +109,7 @@ class MotionController<T extends Object> extends Animation<T>
         ),
         _converter = converter,
         _initialValue = initialValue,
-        _motionPerDimension = List.of(motionPerDimension),
+        _motionPerDimension = List.of(motionPerDimension, growable: false),
         _animationBehavior = behavior {
     _inner = TrackController(
       vsync: vsync,

--- a/packages/motor/lib/src/controllers/track_controller.dart
+++ b/packages/motor/lib/src/controllers/track_controller.dart
@@ -54,6 +54,9 @@ class TrackController extends Animation<TrackValueReader>
   final Map<Track, _TrackSlot> _slots = {};
   final Map<Track, int> _lastStepByTrack = {};
   final Set<Track> _activeTracks = {};
+  /// Reused each [_tick] so `onStep` can mutate [_activeTracks] safely without
+  /// allocating a fresh list every frame.
+  final List<Track> _activeTracksScratch = <Track>[];
   final Map<Object, Set<Track>> _tokenParticipants = {};
   final Map<Track, MotionVelocityTracker<Object>> _velocityTrackers = {};
   final Map<Track, Motion> _motionOverrides = {};
@@ -164,8 +167,7 @@ class TrackController extends Animation<TrackValueReader>
     final estimate =
         (tracker as MotionVelocityTracker<T>).getVelocityEstimate();
     if (estimate != null) {
-      _slots[track]!._velocityValues =
-          track.converter.normalize(estimate.perSecond);
+      _slots[track]!.setVelocity(estimate.perSecond);
     }
   }
 
@@ -751,13 +753,20 @@ class TrackController extends Animation<TrackValueReader>
   bool onPlaybackCompleted() => false;
 
   void _tick(Duration elapsed) {
-    final logicalElapsed = Duration(
-      microseconds: (elapsed.inMicroseconds * _playbackSpeed).round(),
-    );
+    // Avoid a Duration alloc on the common path (speed == 1).
+    final logicalElapsed = _playbackSpeed == 1.0
+        ? elapsed
+        : Duration(
+            microseconds: (elapsed.inMicroseconds * _playbackSpeed).round(),
+          );
     _lastElapsed = logicalElapsed;
     var allDone = true;
 
-    for (final track in _activeTracks.toList()) {
+    // Snapshot into a reused list: [onStep] may start/stop tracks mid-loop.
+    final tracks = _activeTracksScratch
+      ..clear()
+      ..addAll(_activeTracks);
+    for (final track in tracks) {
       final slot = _slots[track];
       if (slot == null) continue;
       if (!slot.tick(logicalElapsed)) {

--- a/packages/motor/lib/src/motion_converter.dart
+++ b/packages/motor/lib/src/motion_converter.dart
@@ -78,10 +78,11 @@ abstract class MotionConverter<T> {
   T lerp(T a, T b, double t) {
     final aValues = normalize(a);
     final bValues = normalize(b);
-    final resultValues = <double>[];
-    for (var i = 0; i < aValues.length; i++) {
-      resultValues.add(lerpDouble(aValues[i], bValues[i], t)!);
-    }
+    final resultValues = List<double>.generate(
+      aValues.length,
+      (i) => lerpDouble(aValues[i], bValues[i], t)!,
+      growable: false,
+    );
     return denormalize(resultValues);
   }
 }
@@ -136,7 +137,8 @@ class SingleMotionConverter extends MotionConverter<double>
   const SingleMotionConverter();
 
   @override
-  List<double> normalize(double value) => [value];
+  List<double> normalize(double value) =>
+      List<double>.filled(1, value);
 
   @override
   double denormalize(List<double> values) => values[0];
@@ -148,7 +150,8 @@ class OffsetMotionConverter extends MotionConverter<Offset> {
   const OffsetMotionConverter();
 
   @override
-  List<double> normalize(Offset value) => [value.dx, value.dy];
+  List<double> normalize(Offset value) =>
+      List<double>.of([value.dx, value.dy], growable: false);
 
   @override
   Offset denormalize(List<double> values) => Offset(values[0], values[1]);
@@ -160,7 +163,8 @@ class SizeMotionConverter extends MotionConverter<Size> {
   const SizeMotionConverter();
 
   @override
-  List<double> normalize(Size value) => [value.width, value.height];
+  List<double> normalize(Size value) =>
+      List<double>.of([value.width, value.height], growable: false);
 
   @override
   Size denormalize(List<double> values) => Size(values[0], values[1]);
@@ -172,12 +176,10 @@ class RectMotionConverter extends MotionConverter<Rect> {
   const RectMotionConverter();
 
   @override
-  List<double> normalize(Rect value) => [
-        value.left,
-        value.top,
-        value.right,
-        value.bottom,
-      ];
+  List<double> normalize(Rect value) => List<double>.of(
+        [value.left, value.top, value.right, value.bottom],
+        growable: false,
+      );
 
   @override
   Rect denormalize(List<double> values) => Rect.fromLTRB(
@@ -194,7 +196,8 @@ class AlignmentMotionConverter extends MotionConverter<Alignment> {
   const AlignmentMotionConverter();
 
   @override
-  List<double> normalize(Alignment value) => [value.x, value.y];
+  List<double> normalize(Alignment value) =>
+      List<double>.of([value.x, value.y], growable: false);
 
   @override
   Alignment denormalize(List<double> values) => Alignment(values[0], values[1]);
@@ -206,12 +209,10 @@ class ColorRgbMotionConverter extends MotionConverter<Color> {
   const ColorRgbMotionConverter();
 
   @override
-  List<double> normalize(Color value) => [
-        value.r,
-        value.g,
-        value.b,
-        value.a,
-      ];
+  List<double> normalize(Color value) => List<double>.of(
+        [value.r, value.g, value.b, value.a],
+        growable: false,
+      );
 
   @override
   Color denormalize(List<double> values) => Color.from(
@@ -228,12 +229,10 @@ class EdgeInsetsMotionConverter extends MotionConverter<EdgeInsets> {
   const EdgeInsetsMotionConverter();
 
   @override
-  List<double> normalize(EdgeInsets value) => [
-        value.left,
-        value.top,
-        value.right,
-        value.bottom,
-      ];
+  List<double> normalize(EdgeInsets value) => List<double>.of(
+        [value.left, value.top, value.right, value.bottom],
+        growable: false,
+      );
 
   @override
   EdgeInsets denormalize(List<double> values) => EdgeInsets.fromLTRB(
@@ -251,12 +250,10 @@ class EdgeInsetsDirectionalMotionConverter
   const EdgeInsetsDirectionalMotionConverter();
 
   @override
-  List<double> normalize(EdgeInsetsDirectional value) => [
-        value.start,
-        value.top,
-        value.end,
-        value.bottom,
-      ];
+  List<double> normalize(EdgeInsetsDirectional value) => List<double>.of(
+        [value.start, value.top, value.end, value.bottom],
+        growable: false,
+      );
 
   @override
   EdgeInsetsDirectional denormalize(List<double> values) =>

--- a/packages/motor/lib/src/motion_velocity_tracker.dart
+++ b/packages/motor/lib/src/motion_velocity_tracker.dart
@@ -125,9 +125,11 @@ class MotionVelocityTracker<T> {
     final dtMs = dt.toDouble() / 1000.0;
 
     // (end - start) * 1000 / dtMs
-    return List.generate(end.$1.length, (i) {
-      return (end.$1[i] - start.$1[i]) * 1000 / dtMs;
-    });
+    return List.generate(
+      end.$1.length,
+      (i) => (end.$1[i] - start.$1[i]) * 1000 / dtMs,
+      growable: false,
+    );
   }
 
   /// Returns a velocity estimate based on recent position samples.
@@ -191,9 +193,11 @@ class MotionVelocityTracker<T> {
     }
 
     // Offset
-    final offsetValues = List.generate(dims, (i) {
-      return newestSample.$1[i] - oldestNonNullSample!.$1[i];
-    });
+    final offsetValues = List.generate(
+      dims,
+      (i) => newestSample.$1[i] - oldestNonNullSample!.$1[i],
+      growable: false,
+    );
 
     return MotionVelocityEstimate<T>(
       perSecond: converter.denormalize(estimatedVelocityValues),

--- a/packages/motor/lib/src/simulations/step_playback.dart
+++ b/packages/motor/lib/src/simulations/step_playback.dart
@@ -40,11 +40,15 @@ class StepPlayback<T extends Object> {
         _loop = loop,
         _fallbackMotion = fallbackMotion,
         _fallbackMotionPerDimension = fallbackMotionPerDimension,
-        _initialValues = converter.normalize(start),
+        _initialValues =
+            List<double>.of(converter.normalize(start), growable: false),
         _initialVelocities = switch (velocity) {
           null => List<double>.filled(converter.normalize(start).length, 0),
-          final value => converter.normalize(value),
+          final value =>
+            List<double>.of(converter.normalize(value), growable: false),
         } {
+    _currentValues = List<double>.of(_initialValues, growable: false);
+    _currentVelocities = List<double>.of(_initialVelocities, growable: false);
     if (loop == LoopMode.loop) {
       // `loop` animates back to the start after the last step. Model that as a
       // synthetic final step that returns to the start snapshot, reusing the
@@ -130,8 +134,8 @@ class StepPlayback<T extends Object> {
   /// The slot-local time at which each forward step began in this cycle.
   late final List<double?> _stepStartSeconds;
 
-  late List<double> _currentValues;
-  late List<double> _currentVelocities;
+  late final List<double> _currentValues;
+  late final List<double> _currentVelocities;
   late List<Simulation> _simulations;
   var _stepIndex = 0;
   var _direction = 1;
@@ -143,14 +147,17 @@ class StepPlayback<T extends Object> {
   var _isWaitingForSync = false;
 
   void _buildWaypoints() {
-    _waypoints = [
-      for (final step in _steps)
-        switch (step) {
-          StepTo<T>(:final value) => _converter.normalize(value),
-          StepAt<T>(:final value) => _converter.normalize(value),
-          _ => List.of(_initialValues),
-        },
-    ];
+    _waypoints = List<List<double>>.of(
+      [
+        for (final step in _steps)
+          switch (step) {
+            StepTo<T>(:final value) => _converter.normalize(value),
+            StepAt<T>(:final value) => _converter.normalize(value),
+            _ => List<double>.of(_initialValues, growable: false),
+          },
+      ],
+      growable: false,
+    );
   }
 
   List<double?> _estimateSegmentDurations({
@@ -214,10 +221,33 @@ class StepPlayback<T extends Object> {
   }
 
   /// Current normalized values.
-  List<double> get values => List.unmodifiable(_currentValues);
+  ///
+  /// The list is owned by this playback and updated in place each sample.
+  /// Callers must not mutate it; use [copyStateInto] to take a snapshot.
+  List<double> get values => _currentValues;
 
   /// Current normalized velocities.
-  List<double> get velocities => List.unmodifiable(_currentVelocities);
+  ///
+  /// The list is owned by this playback and updated in place each sample.
+  /// Callers must not mutate it; use [copyStateInto] to take a snapshot.
+  List<double> get velocities => _currentVelocities;
+
+  /// Copies the current value/velocity buffers into [values] / [velocities].
+  ///
+  /// [values] and [velocities] must already have length [_dimensions].
+  @internal
+  void copyStateInto(List<double> values, List<double> velocities) {
+    _copyDoubles(values, _currentValues);
+    _copyDoubles(velocities, _currentVelocities);
+  }
+
+  /// Adopts this playback's live buffers for zero-copy reads while animating.
+  ///
+  /// The returned lists stay valid for the lifetime of this [StepPlayback] and
+  /// are mutated in place by [advanceTo] / [seekTo].
+  @internal
+  (List<double>, List<double>) borrowStateBuffers() =>
+      (_currentValues, _currentVelocities);
 
   /// The currently active step index.
   int get currentStepIndex => _isDone ? -1 : _stepIndex;
@@ -378,8 +408,7 @@ class StepPlayback<T extends Object> {
   }
 
   void _reset() {
-    _currentValues = List.of(_initialValues);
-    _currentVelocities = List.of(_initialVelocities);
+    _snapToInitial();
     _stepIndex = 0;
     _direction = 1;
     _cycle = 0;
@@ -393,6 +422,21 @@ class StepPlayback<T extends Object> {
     }
     _startCurrentStep();
     _sample(0);
+  }
+
+  void _snapToInitial() {
+    _copyDoubles(_currentValues, _initialValues);
+    _copyDoubles(_currentVelocities, _initialVelocities);
+  }
+
+  static void _copyDoubles(List<double> target, List<double> source) {
+    assert(
+      target.length == source.length,
+      'buffer length mismatch: ${target.length} != ${source.length}',
+    );
+    for (var i = 0; i < target.length; i++) {
+      target[i] = source[i];
+    }
   }
 
   void _advanceStep() {
@@ -409,8 +453,7 @@ class StepPlayback<T extends Object> {
           // cycle from there without jumping. Timelines without a target
           // motion have no return step, so restart from their initial state.
           if (!_hasReturnStep) {
-            _currentValues = List.of(_initialValues);
-            _currentVelocities = List.of(_initialVelocities);
+            _snapToInitial();
           }
           _cycleStartSeconds = _segmentStartSeconds;
           _cycle++;
@@ -424,8 +467,7 @@ class StepPlayback<T extends Object> {
         case LoopMode.seamless:
           // Jump straight back to the start snapshot and replay. The timeline
           // is expected to end where it began, so the jump is invisible.
-          _currentValues = List.of(_initialValues);
-          _currentVelocities = List.of(_initialVelocities);
+          _snapToInitial();
           _cycleStartSeconds = _segmentStartSeconds;
           _cycle++;
           _stepIndex = 0;
@@ -495,61 +537,64 @@ class StepPlayback<T extends Object> {
     _stepStartSeconds[_stepIndex] = _segmentStartSeconds;
     final step = _steps[_stepIndex];
     _simulations = switch (step) {
-      StepTo<T>(:final value, :final motion, :final motionPerDimension) => () {
+      StepTo<T>(:final motion, :final motionPerDimension) => () {
           final motions = _motions(motion, motionPerDimension);
-          final targets = _converter.normalize(value);
-          return [
-            for (var i = 0; i < targets.length; i++)
-              motions[i].createSimulation(
-                start: _currentValues[i],
-                end: targets[i],
-                velocity: _currentVelocities[i],
-              ),
-          ];
-        }(),
-      StepFree<T>(:final motion) => [
-          for (var i = 0; i < _currentValues.length; i++)
-            motion.createSimulation(
+          // Prefer precomputed waypoints — avoid normalize() alloc per step.
+          final targets = _waypoints[_stepIndex];
+          return List<Simulation>.generate(
+            targets.length,
+            (i) => motions[i].createSimulation(
               start: _currentValues[i],
+              end: targets[i],
               velocity: _currentVelocities[i],
             ),
-        ],
-      StepHold<T>(:final duration) => [
-          for (final value in _currentValues)
-            _HoldSimulation(
-              value: value,
-              duration: duration.toSeconds(),
-            ),
-        ],
-      StepAt<T>(
-        :final at,
-        :final value,
-        :final motion,
-        :final motionPerDimension,
-      ) =>
-        () {
+            growable: false,
+          );
+        }(),
+      StepFree<T>(:final motion) => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => motion.createSimulation(
+            start: _currentValues[i],
+            velocity: _currentVelocities[i],
+          ),
+          growable: false,
+        ),
+      StepHold<T>(:final duration) => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => _HoldSimulation(
+            value: _currentValues[i],
+            duration: duration.toSeconds(),
+          ),
+          growable: false,
+        ),
+      StepAt<T>(:final at, :final motion, :final motionPerDimension) => () {
           final motions = _motions(motion, motionPerDimension);
-          final targets = _converter.normalize(value);
+          final targets = _waypoints[_stepIndex];
           final gap = _absoluteTimeFor(at) - _segmentStartSeconds;
           final atMotions = gap > 0
-              ? [
-                  for (final m in motions)
-                    m.scaleTo(Duration(microseconds: (gap * 1000000).round())),
-                ]
+              ? List<Motion>.generate(
+                  motions.length,
+                  (i) => motions[i].scaleTo(
+                    Duration(microseconds: (gap * 1000000).round()),
+                  ),
+                  growable: false,
+                )
               : motions;
-          return [
-            for (var i = 0; i < targets.length; i++)
-              atMotions[i].createSimulation(
-                start: _currentValues[i],
-                end: targets[i],
-                velocity: _currentVelocities[i],
-              ),
-          ];
+          return List<Simulation>.generate(
+            targets.length,
+            (i) => atMotions[i].createSimulation(
+              start: _currentValues[i],
+              end: targets[i],
+              velocity: _currentVelocities[i],
+            ),
+            growable: false,
+          );
         }(),
-      StepSync<T>() => [
-          for (final value in _currentValues)
-            _HoldSimulation(value: value, duration: 0),
-        ],
+      StepSync<T>() => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => _HoldSimulation(value: _currentValues[i], duration: 0),
+          growable: false,
+        ),
     };
   }
 
@@ -567,14 +612,15 @@ class StepPlayback<T extends Object> {
           final resolved = _motionsOrNull(motion, motionPerDimension);
           final forwardSeconds = _forwardSegmentSeconds[_stepIndex];
           if (resolved == null || forwardSeconds == null) return resolved;
-          return [
-            for (final motion in resolved)
-              motion.scaleTo(
-                Duration(
-                  microseconds: (forwardSeconds * 1000000).round(),
-                ),
+          return List<Motion>.generate(
+            resolved.length,
+            (i) => resolved[i].scaleTo(
+              Duration(
+                microseconds: (forwardSeconds * 1000000).round(),
               ),
-          ];
+            ),
+            growable: false,
+          );
         }(),
       StepFree<T>() => null,
       StepHold<T>() => null,
@@ -582,14 +628,15 @@ class StepPlayback<T extends Object> {
     };
 
     if (motions != null) {
-      _simulations = [
-        for (var i = 0; i < targets.length; i++)
-          motions[i].createSimulation(
-            start: _currentValues[i],
-            end: targets[i],
-            velocity: _currentVelocities[i],
-          ),
-      ];
+      _simulations = List<Simulation>.generate(
+        targets.length,
+        (i) => motions[i].createSimulation(
+          start: _currentValues[i],
+          end: targets[i],
+          velocity: _currentVelocities[i],
+        ),
+        growable: false,
+      );
     } else {
       // For free/hold steps in reverse, use a hold at current values with the
       // same duration.
@@ -597,10 +644,11 @@ class StepPlayback<T extends Object> {
         StepHold<T>(:final duration) => duration.toSeconds(),
         _ => 0.0,
       };
-      _simulations = [
-        for (final value in _currentValues)
-          _HoldSimulation(value: value, duration: duration),
-      ];
+      _simulations = List<Simulation>.generate(
+        _currentValues.length,
+        (i) => _HoldSimulation(value: _currentValues[i], duration: duration),
+        growable: false,
+      );
     }
   }
 
@@ -629,12 +677,12 @@ class StepPlayback<T extends Object> {
 
   void _sample(double localSeconds) {
     final t = localSeconds < 0 ? 0.0 : localSeconds;
-    _currentValues = [
-      for (final simulation in _simulations) simulation.x(t),
-    ];
-    _currentVelocities = [
-      for (final simulation in _simulations) simulation.dx(t),
-    ];
+    final simulations = _simulations;
+    // Mutate in place — called every tick; avoid allocating new lists.
+    for (var i = 0; i < simulations.length; i++) {
+      _currentValues[i] = simulations[i].x(t);
+      _currentVelocities[i] = simulations[i].dx(t);
+    }
   }
 
   bool _segmentIsDone(double localSeconds) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 workspace:
   - apps/example
+  - benchmark
   - packages/example_design
   - packages/heroine
   - packages/heroine/example
@@ -80,6 +81,15 @@ melos:
       run: melos run coverage:select --no-select
       description: Generate coverage for all packages.
     
+    benchmark:
+      run: flutter test test/run_benchmarks_test.dart --reporter expanded
+      exec:
+        concurrency: 1
+        failFast: true
+      packageFilters:
+        scope: motor_benchmark
+      description: Run Motor vs AnimationController microbenchmarks.
+
     generate:select:
       description: Run code generation for selected packages.
       run: dart run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
## Summary
- Add a `benchmark/` package comparing Motor to Flutter `AnimationController` (tick + pump layers, multi-track scale, interrupt, widget rebuild, velocity-tracking overhead).
- Cut hot-path allocations in Motor: in-place sampling (no per-frame `List.of`), fixed-length buffers (`growable: false`), eager denormalized value/velocity cache on `_TrackSlot`, reuse `_waypoints` when starting steps, and a reused scratch list instead of `_activeTracks.toList()` every tick.
- Document findings in `benchmark/ANALYSIS.md` / `benchmark/README.md`; wire `melos run benchmark`.

## Motivation
Motor’s architecture (1 ticker × N tracks) should scale better than N `AnimationController`s, but early benches were dominated by short-lived list/object allocs on the notify/read path. After these changes, full-suite pump results look much healthier — especially multi-track and interrupt/retarget.

## Benchmark highlights (full suite, n=7, pump p50 Δ)
| Scenario | Δ vs AC |
|---|---:|
| Single spring (1D) | −2.0% |
| Offset spring (2D) | +4.8% |
| Multi-track ×50 / ×500 | −9.7% / −11.8% |
| Interrupt / retarget | +27% (was ~+48% pre-cache/waypoints) |
| Widget rebuild | −22.9% |

## Test plan
- [ ] `cd packages/motor && flutter test test/src/controllers test/src/step_playback*.dart`
- [ ] `cd benchmark && flutter test test/run_benchmarks_test.dart --reporter expanded`
- [ ] Optional smoke: `BENCH_QUICK=1 flutter test test/run_benchmarks_test.dart`
- [ ] Skim `benchmark/ANALYSIS.md` for result interpretation

Happy for you to take or leave whichever pieces fit `motor/2.0` — the harness and the hot-path diffs can land separately if you prefer.