### PR TITLE
perf(motor): cut hot-path allocations

### DIFF
--- a/packages/motor/lib/src/controllers/_track_slot.dart
+++ b/packages/motor/lib/src/controllers/_track_slot.dart
@@ -6,26 +6,35 @@ class _TrackSlot<T extends Object> {
     required T initialValue,
     this.fallbackMotion,
     this.fallbackMotionPerDimension,
-  })  : _currentValues = converter.normalize(initialValue),
-        _velocityValues = List<double>.filled(
-          converter.normalize(initialValue).length,
-          0,
-        );
+  }) : _cachedValue = initialValue {
+    final normalized = converter.normalize(initialValue);
+    _currentValues = normalized;
+    _velocityValues = List<double>.filled(normalized.length, 0);
+    _cachedVelocity = converter.denormalize(_velocityValues);
+  }
 
   final MotionConverter<T> converter;
   final Motion? fallbackMotion;
   final List<Motion>? fallbackMotionPerDimension;
 
-  List<double> _currentValues;
-  List<double> _velocityValues;
+  late List<double> _currentValues;
+  late List<double> _velocityValues;
+  late T _cachedValue;
+  late T _cachedVelocity;
   StepPlayback<T>? _stepPlayback;
   _TrackSlotPlayback _playback = _TrackSlotPlayback.idle;
   Duration _startOffset = Duration.zero;
   Duration _inspectionStartOffset = Duration.zero;
 
-  T get value => converter.denormalize(_currentValues);
+  /// True while [_currentValues] / [_velocityValues] alias [StepPlayback]
+  /// buffers. Cleared on [stop] / [setValue] so the slot keeps a private copy.
+  var _borrowingPlaybackBuffers = false;
 
-  T get velocity => converter.denormalize(_velocityValues);
+  /// Eager denormalized value — refreshed after each sample, not on every read.
+  T get value => _cachedValue;
+
+  /// Eager denormalized velocity — refreshed after each sample.
+  T get velocity => _cachedVelocity;
 
   bool get isAnimating => _playback != _TrackSlotPlayback.idle;
 
@@ -43,17 +52,29 @@ class _TrackSlot<T extends Object> {
       _stepPlayback?.hasPassedSync(token) ?? false;
 
   void setValue(T value) {
+    _detachPlaybackBuffers();
     _currentValues = converter.normalize(value);
     _velocityValues = List<double>.filled(_currentValues.length, 0);
+    _cachedValue = value;
+    _cachedVelocity = converter.denormalize(_velocityValues);
     _stepPlayback = null;
     _playback = _TrackSlotPlayback.idle;
   }
 
   void setValueWithVelocity(T value, T velocity) {
+    _detachPlaybackBuffers();
     _currentValues = converter.normalize(value);
     _velocityValues = converter.normalize(velocity);
+    _cachedValue = value;
+    _cachedVelocity = velocity;
     _stepPlayback = null;
     _playback = _TrackSlotPlayback.idle;
+  }
+
+  /// Updates velocity buffers from an external estimate (e.g. gesture tracking).
+  void setVelocity(T velocity) {
+    _velocityValues = converter.normalize(velocity);
+    _cachedVelocity = velocity;
   }
 
   void play(
@@ -76,9 +97,13 @@ class _TrackSlot<T extends Object> {
       fallbackMotionPerDimension: fallbackMotionPerDimension,
       estimateDurations: estimateDurations,
     );
-    _currentValues = List.of(_stepPlayback!.values);
-    _velocityValues = List.of(_stepPlayback!.velocities);
+    // Zero-copy: read through the playback buffers mutated in place each tick.
+    final buffers = _stepPlayback!.borrowStateBuffers();
+    _currentValues = buffers.$1;
+    _velocityValues = buffers.$2;
+    _borrowingPlaybackBuffers = true;
     _playback = _TrackSlotPlayback.chained;
+    _refreshCaches();
   }
 
   double _localSeconds(Duration elapsed) {
@@ -102,6 +127,7 @@ class _TrackSlot<T extends Object> {
       _TrackSlotPlayback.chained => _tickStepPlayback(seconds),
     };
 
+    _refreshCaches();
     if (done) {
       _playback = _TrackSlotPlayback.idle;
     }
@@ -115,10 +141,12 @@ class _TrackSlot<T extends Object> {
     }
 
     final seconds = _inspectionSeconds(elapsed);
-    return switch (_playback) {
+    final done = switch (_playback) {
       _TrackSlotPlayback.idle => true,
       _TrackSlotPlayback.chained => _seekStepPlayback(seconds),
     };
+    _refreshCaches();
+    return done;
   }
 
   /// Re-bases the controller axis around this slot's current local playhead.
@@ -134,19 +162,12 @@ class _TrackSlot<T extends Object> {
   }
 
   bool _tickStepPlayback(double seconds) {
-    final playback = _stepPlayback!;
-    final done = playback.advanceTo(seconds);
-    _currentValues = List.of(playback.values);
-    _velocityValues = List.of(playback.velocities);
-    return done;
+    // Buffers are aliased; advanceTo samples in place — no List.of.
+    return _stepPlayback!.advanceTo(seconds);
   }
 
   bool _seekStepPlayback(double seconds) {
-    final playback = _stepPlayback!;
-    final done = playback.seekTo(seconds);
-    _currentValues = List.of(playback.values);
-    _velocityValues = List.of(playback.velocities);
-    return done;
+    return _stepPlayback!.seekTo(seconds);
   }
 
   /// Redirects this slot to settle at its current value using the fallback
@@ -172,9 +193,26 @@ class _TrackSlot<T extends Object> {
   }
 
   void stop({bool canceled = false}) {
+    _detachPlaybackBuffers();
+    for (var i = 0; i < _velocityValues.length; i++) {
+      _velocityValues[i] = 0;
+    }
+    _cachedVelocity = converter.denormalize(_velocityValues);
     _stepPlayback = null;
-    _velocityValues = List<double>.filled(_currentValues.length, 0);
     _playback = _TrackSlotPlayback.idle;
+  }
+
+  /// Takes ownership of the current buffers so [StepPlayback] can be dropped.
+  void _detachPlaybackBuffers() {
+    if (!_borrowingPlaybackBuffers) return;
+    _currentValues = List<double>.of(_currentValues, growable: false);
+    _velocityValues = List<double>.of(_velocityValues, growable: false);
+    _borrowingPlaybackBuffers = false;
+  }
+
+  void _refreshCaches() {
+    _cachedValue = converter.denormalize(_currentValues);
+    _cachedVelocity = converter.denormalize(_velocityValues);
   }
 
   int get currentStepIndex => _stepPlayback?.currentStepIndex ?? -1;

--- a/packages/motor/lib/src/controllers/motion_controller.dart
+++ b/packages/motor/lib/src/controllers/motion_controller.dart
@@ -109,7 +109,7 @@ class MotionController<T extends Object> extends Animation<T>
         ),
         _converter = converter,
         _initialValue = initialValue,
-        _motionPerDimension = List.of(motionPerDimension),
+        _motionPerDimension = List.of(motionPerDimension, growable: false),
         _animationBehavior = behavior {
     _inner = TrackController(
       vsync: vsync,

--- a/packages/motor/lib/src/controllers/track_controller.dart
+++ b/packages/motor/lib/src/controllers/track_controller.dart
@@ -54,6 +54,9 @@ class TrackController extends Animation<TrackValueReader>
   final Map<Track, _TrackSlot> _slots = {};
   final Map<Track, int> _lastStepByTrack = {};
   final Set<Track> _activeTracks = {};
+  /// Reused each [_tick] so `onStep` can mutate [_activeTracks] safely without
+  /// allocating a fresh list every frame.
+  final List<Track> _activeTracksScratch = <Track>[];
   final Map<Object, Set<Track>> _tokenParticipants = {};
   final Map<Track, MotionVelocityTracker<Object>> _velocityTrackers = {};
   final Map<Track, Motion> _motionOverrides = {};
@@ -164,8 +167,7 @@ class TrackController extends Animation<TrackValueReader>
     final estimate =
         (tracker as MotionVelocityTracker<T>).getVelocityEstimate();
     if (estimate != null) {
-      _slots[track]!._velocityValues =
-          track.converter.normalize(estimate.perSecond);
+      _slots[track]!.setVelocity(estimate.perSecond);
     }
   }
 
@@ -751,13 +753,20 @@ class TrackController extends Animation<TrackValueReader>
   bool onPlaybackCompleted() => false;
 
   void _tick(Duration elapsed) {
-    final logicalElapsed = Duration(
-      microseconds: (elapsed.inMicroseconds * _playbackSpeed).round(),
-    );
+    // Avoid a Duration alloc on the common path (speed == 1).
+    final logicalElapsed = _playbackSpeed == 1.0
+        ? elapsed
+        : Duration(
+            microseconds: (elapsed.inMicroseconds * _playbackSpeed).round(),
+          );
     _lastElapsed = logicalElapsed;
     var allDone = true;
 
-    for (final track in _activeTracks.toList()) {
+    // Snapshot into a reused list: [onStep] may start/stop tracks mid-loop.
+    final tracks = _activeTracksScratch
+      ..clear()
+      ..addAll(_activeTracks);
+    for (final track in tracks) {
       final slot = _slots[track];
       if (slot == null) continue;
       if (!slot.tick(logicalElapsed)) {

--- a/packages/motor/lib/src/motion_converter.dart
+++ b/packages/motor/lib/src/motion_converter.dart
@@ -78,10 +78,11 @@ abstract class MotionConverter<T> {
   T lerp(T a, T b, double t) {
     final aValues = normalize(a);
     final bValues = normalize(b);
-    final resultValues = <double>[];
-    for (var i = 0; i < aValues.length; i++) {
-      resultValues.add(lerpDouble(aValues[i], bValues[i], t)!);
-    }
+    final resultValues = List<double>.generate(
+      aValues.length,
+      (i) => lerpDouble(aValues[i], bValues[i], t)!,
+      growable: false,
+    );
     return denormalize(resultValues);
   }
 }
@@ -136,7 +137,8 @@ class SingleMotionConverter extends MotionConverter<double>
   const SingleMotionConverter();
 
   @override
-  List<double> normalize(double value) => [value];
+  List<double> normalize(double value) =>
+      List<double>.filled(1, value);
 
   @override
   double denormalize(List<double> values) => values[0];
@@ -148,7 +150,8 @@ class OffsetMotionConverter extends MotionConverter<Offset> {
   const OffsetMotionConverter();
 
   @override
-  List<double> normalize(Offset value) => [value.dx, value.dy];
+  List<double> normalize(Offset value) =>
+      List<double>.of([value.dx, value.dy], growable: false);
 
   @override
   Offset denormalize(List<double> values) => Offset(values[0], values[1]);
@@ -160,7 +163,8 @@ class SizeMotionConverter extends MotionConverter<Size> {
   const SizeMotionConverter();
 
   @override
-  List<double> normalize(Size value) => [value.width, value.height];
+  List<double> normalize(Size value) =>
+      List<double>.of([value.width, value.height], growable: false);
 
   @override
   Size denormalize(List<double> values) => Size(values[0], values[1]);
@@ -172,12 +176,10 @@ class RectMotionConverter extends MotionConverter<Rect> {
   const RectMotionConverter();
 
   @override
-  List<double> normalize(Rect value) => [
-        value.left,
-        value.top,
-        value.right,
-        value.bottom,
-      ];
+  List<double> normalize(Rect value) => List<double>.of(
+        [value.left, value.top, value.right, value.bottom],
+        growable: false,
+      );
 
   @override
   Rect denormalize(List<double> values) => Rect.fromLTRB(
@@ -194,7 +196,8 @@ class AlignmentMotionConverter extends MotionConverter<Alignment> {
   const AlignmentMotionConverter();
 
   @override
-  List<double> normalize(Alignment value) => [value.x, value.y];
+  List<double> normalize(Alignment value) =>
+      List<double>.of([value.x, value.y], growable: false);
 
   @override
   Alignment denormalize(List<double> values) => Alignment(values[0], values[1]);
@@ -206,12 +209,10 @@ class ColorRgbMotionConverter extends MotionConverter<Color> {
   const ColorRgbMotionConverter();
 
   @override
-  List<double> normalize(Color value) => [
-        value.r,
-        value.g,
-        value.b,
-        value.a,
-      ];
+  List<double> normalize(Color value) => List<double>.of(
+        [value.r, value.g, value.b, value.a],
+        growable: false,
+      );
 
   @override
   Color denormalize(List<double> values) => Color.from(
@@ -228,12 +229,10 @@ class EdgeInsetsMotionConverter extends MotionConverter<EdgeInsets> {
   const EdgeInsetsMotionConverter();
 
   @override
-  List<double> normalize(EdgeInsets value) => [
-        value.left,
-        value.top,
-        value.right,
-        value.bottom,
-      ];
+  List<double> normalize(EdgeInsets value) => List<double>.of(
+        [value.left, value.top, value.right, value.bottom],
+        growable: false,
+      );
 
   @override
   EdgeInsets denormalize(List<double> values) => EdgeInsets.fromLTRB(
@@ -251,12 +250,10 @@ class EdgeInsetsDirectionalMotionConverter
   const EdgeInsetsDirectionalMotionConverter();
 
   @override
-  List<double> normalize(EdgeInsetsDirectional value) => [
-        value.start,
-        value.top,
-        value.end,
-        value.bottom,
-      ];
+  List<double> normalize(EdgeInsetsDirectional value) => List<double>.of(
+        [value.start, value.top, value.end, value.bottom],
+        growable: false,
+      );
 
   @override
   EdgeInsetsDirectional denormalize(List<double> values) =>

--- a/packages/motor/lib/src/motion_velocity_tracker.dart
+++ b/packages/motor/lib/src/motion_velocity_tracker.dart
@@ -125,9 +125,11 @@ class MotionVelocityTracker<T> {
     final dtMs = dt.toDouble() / 1000.0;
 
     // (end - start) * 1000 / dtMs
-    return List.generate(end.$1.length, (i) {
-      return (end.$1[i] - start.$1[i]) * 1000 / dtMs;
-    });
+    return List.generate(
+      end.$1.length,
+      (i) => (end.$1[i] - start.$1[i]) * 1000 / dtMs,
+      growable: false,
+    );
   }
 
   /// Returns a velocity estimate based on recent position samples.
@@ -191,9 +193,11 @@ class MotionVelocityTracker<T> {
     }
 
     // Offset
-    final offsetValues = List.generate(dims, (i) {
-      return newestSample.$1[i] - oldestNonNullSample!.$1[i];
-    });
+    final offsetValues = List.generate(
+      dims,
+      (i) => newestSample.$1[i] - oldestNonNullSample!.$1[i],
+      growable: false,
+    );
 
     return MotionVelocityEstimate<T>(
       perSecond: converter.denormalize(estimatedVelocityValues),

--- a/packages/motor/lib/src/simulations/step_playback.dart
+++ b/packages/motor/lib/src/simulations/step_playback.dart
@@ -40,11 +40,15 @@ class StepPlayback<T extends Object> {
         _loop = loop,
         _fallbackMotion = fallbackMotion,
         _fallbackMotionPerDimension = fallbackMotionPerDimension,
-        _initialValues = converter.normalize(start),
+        _initialValues =
+            List<double>.of(converter.normalize(start), growable: false),
         _initialVelocities = switch (velocity) {
           null => List<double>.filled(converter.normalize(start).length, 0),
-          final value => converter.normalize(value),
+          final value =>
+            List<double>.of(converter.normalize(value), growable: false),
         } {
+    _currentValues = List<double>.of(_initialValues, growable: false);
+    _currentVelocities = List<double>.of(_initialVelocities, growable: false);
     if (loop == LoopMode.loop) {
       // `loop` animates back to the start after the last step. Model that as a
       // synthetic final step that returns to the start snapshot, reusing the
@@ -130,8 +134,8 @@ class StepPlayback<T extends Object> {
   /// The slot-local time at which each forward step began in this cycle.
   late final List<double?> _stepStartSeconds;
 
-  late List<double> _currentValues;
-  late List<double> _currentVelocities;
+  late final List<double> _currentValues;
+  late final List<double> _currentVelocities;
   late List<Simulation> _simulations;
   var _stepIndex = 0;
   var _direction = 1;
@@ -143,14 +147,17 @@ class StepPlayback<T extends Object> {
   var _isWaitingForSync = false;
 
   void _buildWaypoints() {
-    _waypoints = [
-      for (final step in _steps)
-        switch (step) {
-          StepTo<T>(:final value) => _converter.normalize(value),
-          StepAt<T>(:final value) => _converter.normalize(value),
-          _ => List.of(_initialValues),
-        },
-    ];
+    _waypoints = List<List<double>>.of(
+      [
+        for (final step in _steps)
+          switch (step) {
+            StepTo<T>(:final value) => _converter.normalize(value),
+            StepAt<T>(:final value) => _converter.normalize(value),
+            _ => List<double>.of(_initialValues, growable: false),
+          },
+      ],
+      growable: false,
+    );
   }
 
   List<double?> _estimateSegmentDurations({
@@ -214,10 +221,33 @@ class StepPlayback<T extends Object> {
   }
 
   /// Current normalized values.
-  List<double> get values => List.unmodifiable(_currentValues);
+  ///
+  /// The list is owned by this playback and updated in place each sample.
+  /// Callers must not mutate it; use [copyStateInto] to take a snapshot.
+  List<double> get values => _currentValues;
 
   /// Current normalized velocities.
-  List<double> get velocities => List.unmodifiable(_currentVelocities);
+  ///
+  /// The list is owned by this playback and updated in place each sample.
+  /// Callers must not mutate it; use [copyStateInto] to take a snapshot.
+  List<double> get velocities => _currentVelocities;
+
+  /// Copies the current value/velocity buffers into [values] / [velocities].
+  ///
+  /// [values] and [velocities] must already have length [_dimensions].
+  @internal
+  void copyStateInto(List<double> values, List<double> velocities) {
+    _copyDoubles(values, _currentValues);
+    _copyDoubles(velocities, _currentVelocities);
+  }
+
+  /// Adopts this playback's live buffers for zero-copy reads while animating.
+  ///
+  /// The returned lists stay valid for the lifetime of this [StepPlayback] and
+  /// are mutated in place by [advanceTo] / [seekTo].
+  @internal
+  (List<double>, List<double>) borrowStateBuffers() =>
+      (_currentValues, _currentVelocities);
 
   /// The currently active step index.
   int get currentStepIndex => _isDone ? -1 : _stepIndex;
@@ -378,8 +408,7 @@ class StepPlayback<T extends Object> {
   }
 
   void _reset() {
-    _currentValues = List.of(_initialValues);
-    _currentVelocities = List.of(_initialVelocities);
+    _snapToInitial();
     _stepIndex = 0;
     _direction = 1;
     _cycle = 0;
@@ -393,6 +422,21 @@ class StepPlayback<T extends Object> {
     }
     _startCurrentStep();
     _sample(0);
+  }
+
+  void _snapToInitial() {
+    _copyDoubles(_currentValues, _initialValues);
+    _copyDoubles(_currentVelocities, _initialVelocities);
+  }
+
+  static void _copyDoubles(List<double> target, List<double> source) {
+    assert(
+      target.length == source.length,
+      'buffer length mismatch: ${target.length} != ${source.length}',
+    );
+    for (var i = 0; i < target.length; i++) {
+      target[i] = source[i];
+    }
   }
 
   void _advanceStep() {
@@ -409,8 +453,7 @@ class StepPlayback<T extends Object> {
           // cycle from there without jumping. Timelines without a target
           // motion have no return step, so restart from their initial state.
           if (!_hasReturnStep) {
-            _currentValues = List.of(_initialValues);
-            _currentVelocities = List.of(_initialVelocities);
+            _snapToInitial();
           }
           _cycleStartSeconds = _segmentStartSeconds;
           _cycle++;
@@ -424,8 +467,7 @@ class StepPlayback<T extends Object> {
         case LoopMode.seamless:
           // Jump straight back to the start snapshot and replay. The timeline
           // is expected to end where it began, so the jump is invisible.
-          _currentValues = List.of(_initialValues);
-          _currentVelocities = List.of(_initialVelocities);
+          _snapToInitial();
           _cycleStartSeconds = _segmentStartSeconds;
           _cycle++;
           _stepIndex = 0;
@@ -495,61 +537,64 @@ class StepPlayback<T extends Object> {
     _stepStartSeconds[_stepIndex] = _segmentStartSeconds;
     final step = _steps[_stepIndex];
     _simulations = switch (step) {
-      StepTo<T>(:final value, :final motion, :final motionPerDimension) => () {
+      StepTo<T>(:final motion, :final motionPerDimension) => () {
           final motions = _motions(motion, motionPerDimension);
-          final targets = _converter.normalize(value);
-          return [
-            for (var i = 0; i < targets.length; i++)
-              motions[i].createSimulation(
-                start: _currentValues[i],
-                end: targets[i],
-                velocity: _currentVelocities[i],
-              ),
-          ];
-        }(),
-      StepFree<T>(:final motion) => [
-          for (var i = 0; i < _currentValues.length; i++)
-            motion.createSimulation(
+          // Prefer precomputed waypoints — avoid normalize() alloc per step.
+          final targets = _waypoints[_stepIndex];
+          return List<Simulation>.generate(
+            targets.length,
+            (i) => motions[i].createSimulation(
               start: _currentValues[i],
+              end: targets[i],
               velocity: _currentVelocities[i],
             ),
-        ],
-      StepHold<T>(:final duration) => [
-          for (final value in _currentValues)
-            _HoldSimulation(
-              value: value,
-              duration: duration.toSeconds(),
-            ),
-        ],
-      StepAt<T>(
-        :final at,
-        :final value,
-        :final motion,
-        :final motionPerDimension,
-      ) =>
-        () {
+            growable: false,
+          );
+        }(),
+      StepFree<T>(:final motion) => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => motion.createSimulation(
+            start: _currentValues[i],
+            velocity: _currentVelocities[i],
+          ),
+          growable: false,
+        ),
+      StepHold<T>(:final duration) => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => _HoldSimulation(
+            value: _currentValues[i],
+            duration: duration.toSeconds(),
+          ),
+          growable: false,
+        ),
+      StepAt<T>(:final at, :final motion, :final motionPerDimension) => () {
           final motions = _motions(motion, motionPerDimension);
-          final targets = _converter.normalize(value);
+          final targets = _waypoints[_stepIndex];
           final gap = _absoluteTimeFor(at) - _segmentStartSeconds;
           final atMotions = gap > 0
-              ? [
-                  for (final m in motions)
-                    m.scaleTo(Duration(microseconds: (gap * 1000000).round())),
-                ]
+              ? List<Motion>.generate(
+                  motions.length,
+                  (i) => motions[i].scaleTo(
+                    Duration(microseconds: (gap * 1000000).round()),
+                  ),
+                  growable: false,
+                )
               : motions;
-          return [
-            for (var i = 0; i < targets.length; i++)
-              atMotions[i].createSimulation(
-                start: _currentValues[i],
-                end: targets[i],
-                velocity: _currentVelocities[i],
-              ),
-          ];
+          return List<Simulation>.generate(
+            targets.length,
+            (i) => atMotions[i].createSimulation(
+              start: _currentValues[i],
+              end: targets[i],
+              velocity: _currentVelocities[i],
+            ),
+            growable: false,
+          );
         }(),
-      StepSync<T>() => [
-          for (final value in _currentValues)
-            _HoldSimulation(value: value, duration: 0),
-        ],
+      StepSync<T>() => List<Simulation>.generate(
+          _currentValues.length,
+          (i) => _HoldSimulation(value: _currentValues[i], duration: 0),
+          growable: false,
+        ),
     };
   }
 
@@ -567,14 +612,15 @@ class StepPlayback<T extends Object> {
           final resolved = _motionsOrNull(motion, motionPerDimension);
           final forwardSeconds = _forwardSegmentSeconds[_stepIndex];
           if (resolved == null || forwardSeconds == null) return resolved;
-          return [
-            for (final motion in resolved)
-              motion.scaleTo(
-                Duration(
-                  microseconds: (forwardSeconds * 1000000).round(),
-                ),
+          return List<Motion>.generate(
+            resolved.length,
+            (i) => resolved[i].scaleTo(
+              Duration(
+                microseconds: (forwardSeconds * 1000000).round(),
               ),
-          ];
+            ),
+            growable: false,
+          );
         }(),
       StepFree<T>() => null,
       StepHold<T>() => null,
@@ -582,14 +628,15 @@ class StepPlayback<T extends Object> {
     };
 
     if (motions != null) {
-      _simulations = [
-        for (var i = 0; i < targets.length; i++)
-          motions[i].createSimulation(
-            start: _currentValues[i],
-            end: targets[i],
-            velocity: _currentVelocities[i],
-          ),
-      ];
+      _simulations = List<Simulation>.generate(
+        targets.length,
+        (i) => motions[i].createSimulation(
+          start: _currentValues[i],
+          end: targets[i],
+          velocity: _currentVelocities[i],
+        ),
+        growable: false,
+      );
     } else {
       // For free/hold steps in reverse, use a hold at current values with the
       // same duration.
@@ -597,10 +644,11 @@ class StepPlayback<T extends Object> {
         StepHold<T>(:final duration) => duration.toSeconds(),
         _ => 0.0,
       };
-      _simulations = [
-        for (final value in _currentValues)
-          _HoldSimulation(value: value, duration: duration),
-      ];
+      _simulations = List<Simulation>.generate(
+        _currentValues.length,
+        (i) => _HoldSimulation(value: _currentValues[i], duration: duration),
+        growable: false,
+      );
     }
   }
 
@@ -629,12 +677,12 @@ class StepPlayback<T extends Object> {
 
   void _sample(double localSeconds) {
     final t = localSeconds < 0 ? 0.0 : localSeconds;
-    _currentValues = [
-      for (final simulation in _simulations) simulation.x(t),
-    ];
-    _currentVelocities = [
-      for (final simulation in _simulations) simulation.dx(t),
-    ];
+    final simulations = _simulations;
+    // Mutate in place — called every tick; avoid allocating new lists.
+    for (var i = 0; i < simulations.length; i++) {
+      _currentValues[i] = simulations[i].x(t);
+      _currentVelocities[i] = simulations[i].dx(t);
+    }
   }
 
   bool _segmentIsDone(double localSeconds) {


### PR DESCRIPTION
## Summary
- Sample `StepPlayback` value/velocity buffers in place (no per-frame `List.of` copies).
- Use fixed-length lists (`growable: false`) for stable dimension buffers.
- Eager-cache denormalized `T` / velocity on `_TrackSlot` after each sample.
- Reuse precomputed `_waypoints` when starting steps; reuse a scratch list instead of `_activeTracks.toList()` every tick.

## Motivation
Fixed-dimension hot path was creating short-lived growable lists and re-denormalizing on every read. These changes reduce GC pressure without changing public API.

## Test plan
- [ ] `cd packages/motor && flutter test test/src/controllers test/src/step_playback_test.dart test/src/step_playback_seek_parity_test.dart test/src/step_playback_pingpong_test.dart`
- [ ] Smoke existing motor example / known timeline demos

Stacked under: benchmark harness PR (follows this one).

Made with [Cursor](https://cursor.com)