### PR TITLE
refactor(snaptest): replace font loading internals

### DIFF
--- a/packages/snaptest/CHANGELOG.md
+++ b/packages/snaptest/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+ - **REFACTOR**: independently replace the font-loading internals while
+   preserving the public API and rendering behavior.
+
 ## 1.0.0-dev.3
 
 > Note: This release has breaking changes.

--- a/packages/snaptest/CHANGELOG.md
+++ b/packages/snaptest/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-dev.4
 
  - **REFACTOR**: independently replace the font-loading internals while
    preserving the public API and rendering behavior.

--- a/packages/snaptest/lib/src/flutter_sdk_root.dart
+++ b/packages/snaptest/lib/src/flutter_sdk_root.dart
@@ -2,13 +2,30 @@ import 'dart:io';
 
 /// Returns the Flutter SDK root directory based on the current flutter
 /// executable.
-Directory flutterSdkRoot() {
-  final flutterTesterExe = Platform.executable;
-  final String flutterRoot;
-  if (Platform.isWindows) {
-    flutterRoot = flutterTesterExe.split(r'\bin\cache\')[0];
-  } else {
-    flutterRoot = flutterTesterExe.split('/bin/cache/')[0];
+Directory flutterSdkRoot() => flutterSdkRootFromExecutable(
+  Platform.executable,
+  windows: Platform.isWindows,
+);
+
+/// Locates a Flutter SDK above the `bin/cache` segment of [executable].
+///
+/// Flutter widget tests run through `flutter_tester`, which is stored below
+/// that cache directory. A [StateError] is thrown for unrelated executables
+/// instead of silently returning an invalid directory.
+Directory flutterSdkRootFromExecutable(
+  String executable, {
+  required bool windows,
+}) {
+  final normalized = executable.replaceAll(r'\', '/');
+  const cacheSegment = '/bin/cache/';
+  final cacheIndex = normalized.toLowerCase().indexOf(cacheSegment);
+
+  if (cacheIndex < 0) {
+    throw StateError(
+      'Cannot locate the Flutter SDK from executable "$executable".',
+    );
   }
-  return Directory(flutterRoot);
+
+  final root = normalized.substring(0, cacheIndex);
+  return Directory(windows ? root.replaceAll('/', r'\') : root);
 }

--- a/packages/snaptest/lib/src/font_loading.dart
+++ b/packages/snaptest/lib/src/font_loading.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
@@ -10,9 +11,7 @@ import 'package:snaptest/src/flutter_sdk_root.dart';
 import 'package:snaptest/src/snap.dart';
 
 @internal
-const fontFormats = ['.ttf', '.otf', '.ttc'];
-
-bool _fontsLoaded = false;
+const supportedFontExtensions = {'.ttf', '.otf', '.ttc'};
 
 /// Controls how Cupertino system fonts (`CupertinoSystemText` and
 /// `CupertinoSystemDisplay`) are loaded for screenshot rendering.
@@ -120,297 +119,379 @@ class _OverrideCupertinoFonts extends CupertinoFontConfig {
 Future<void> loadFonts({
   CupertinoFontConfig cupertinoFonts = const CupertinoFontConfig.override(),
 }) async {
-  if (_fontsLoaded) return;
   TestWidgetsFlutterBinding.ensureInitialized();
-
-  await _loadMaterialFontsFromSdk();
-  await _loadFontsFromFontManifest();
-
-  switch (cupertinoFonts) {
-    case _MacOsCupertinoFonts(
-      fallbackOverride: final fallbackOverrideFontFamily,
-    ):
-      try {
-        await _loadMacOSFonts();
-      } on _MacOsFontLoadException catch (e) {
-        if (fallbackOverrideFontFamily == null) {
-          throw StateError(
-            'CupertinoFontConfig.fromMacOsSystemFonts() failed: $e\n'
-            'SF Pro fonts are only available on macOS with the fonts '
-            'installed from https://developer.apple.com/fonts/.\n'
-            'To use a fallback font instead, pass '
-            'fallbackOverrideFontFamily, or use '
-            'CupertinoFontConfig.override() for cross-platform consistency.',
-          );
-        }
-        if (fallbackOverrideFontFamily == 'Roboto') {
-          await _overrideCupertinoFontsWithRoboto();
-        } else {
-          await _overrideCupertinoFontsWithFamily(
-            fallbackOverrideFontFamily,
-          );
-        }
-      }
-    case _OverrideCupertinoFonts(:final fontFamily):
-      if (fontFamily == 'Roboto') {
-        await _overrideCupertinoFontsWithRoboto();
-      } else {
-        await _overrideCupertinoFontsWithFamily(fontFamily);
-      }
-  }
-
-  _fontsLoaded = true;
+  await _defaultFontLoading.load(cupertinoFonts);
 }
 
 /// Loads fonts from the given [fromPaths] into the Flutter engine under the
 /// specified [family].
-Future<void> loadFont(String family, List<String> fromPaths) async {
-  if (fromPaths.isEmpty) {
-    return;
-  }
+Future<void> loadFont(String family, List<String> fromPaths) =>
+    _defaultBinaryLoader.load(family, fromPaths);
 
-  await maybeRunAsync(() async {
-    final fontLoader = FontLoader(family);
-    for (final path in fromPaths) {
-      try {
-        final file = File(path);
-        if (file.existsSync()) {
-          final bytes = file.readAsBytesSync();
-          fontLoader.addFont(Future.value(bytes.buffer.asByteData()));
-        } else {
-          final data = rootBundle.load(path);
-          fontLoader.addFont(Future.value(data));
-        }
-      } catch (e, _) {
-        debugPrint("Could not load font $path: $e");
-      }
-    }
+typedef _AsyncScope =
+    Future<T?> Function<T>(
+      Future<T> Function() operation,
+    );
+typedef _FontRegistrar =
+    Future<void> Function(
+      String family,
+      List<ByteData> fonts,
+    );
+typedef _DirectoryReader =
+    List<String> Function(
+      Directory directory, {
+      required bool recursive,
+    });
 
-    await fontLoader.load();
+/// Reads font bytes and submits one complete family to Flutter.
+///
+/// The collaborators are injectable so path selection and registration can be
+/// tested without mutating Flutter's process-wide font collection.
+@internal
+class FontBinaryLoader {
+  const FontBinaryLoader({
+    required this.fileExists,
+    required this.readFile,
+    required this.readBundle,
+    required this.register,
+    required this.runAsync,
+    this.log = debugPrint,
   });
-}
 
-Future<void> _loadMaterialFontsFromSdk() async {
-  final root = flutterSdkRoot().absolute.path;
+  final bool Function(String path) fileExists;
+  final Future<ByteData> Function(String path) readFile;
+  final Future<ByteData> Function(String path) readBundle;
+  final _FontRegistrar register;
+  final _AsyncScope runAsync;
+  final void Function(String message) log;
 
-  final materialFontsDir = Directory(
-    '$root/bin/cache/artifacts/material_fonts/',
-  );
+  Future<void> load(String family, List<String> paths) async {
+    if (paths.isEmpty) return;
 
-  final files = materialFontsDir.listSync().whereType<File>().toList();
-
-  final robotoFonts = files
-      .where((file) => file.isRobotoFont)
-      .map((file) => file.path)
-      .toList();
-
-  await loadFont('Roboto', robotoFonts);
-
-  final robotoCondensedFonts = files
-      .where((file) => file.isRobotoCondensedFont)
-      .map((file) => file.path)
-      .toList();
-  await loadFont('RobotoCondensed', robotoCondensedFonts);
-
-  final materialIcons = files
-      .where((file) => file.isMaterialIconsFont)
-      .map((file) => file.path)
-      .toList();
-  await loadFont('MaterialIcons', materialIcons);
-}
-
-Future<void> _loadFontsFromFontManifest() async {
-  final fontManifestContent = await maybeRunAsync(
-    () => rootBundle.loadString('FontManifest.json'),
-  );
-
-  if (fontManifestContent == null || fontManifestContent.isEmpty) {
-    return;
-  }
-
-  final fontManifestEntries = _parseFontManifest(fontManifestContent);
-
-  for (final (family, assets) in fontManifestEntries) {
-    final packageAsset = assets
-        .where((it) => it.startsWith('packages/'))
-        .firstOrNull;
-    final packageName = packageAsset?.split('/')[1];
-
-    if (packageName == null) {
-      await loadFont(family, assets);
-    } else {
-      final fontFamilyName = family.split('/').last;
-      // We load it both ways to cover both possibilities.
-      await loadFont(fontFamilyName, assets);
-      await loadFont('packages/$packageName/$fontFamilyName', assets);
-    }
+    await runAsync<void>(() async {
+      final binaries = <ByteData>[];
+      for (final path in paths) {
+        try {
+          binaries.add(
+            await (fileExists(path) ? readFile(path) : readBundle(path)),
+          );
+        } on Object catch (error) {
+          log('Could not load font $path: $error');
+        }
+      }
+      await register(family, binaries);
+    });
   }
 }
 
-List<(String, List<String>)> _parseFontManifest(String content) {
-  final fonts = <(String, List<String>)>[];
-  final json = jsonDecode(content) as List<dynamic>;
-  for (final item in json) {
-    if (item is! Map<String, dynamic>) {
-      continue;
-    }
-    final family = item['family'] as String;
-    final assets = (item['fonts'] as List<dynamic>)
-        .cast<Map<String, dynamic>>()
-        .map((font) => font['asset'] as String)
-        .toList();
-    fonts.add((family, assets));
-  }
-  return fonts;
-}
+/// One family and the assets from which it should be registered.
+@immutable
+@internal
+class FontRegistration {
+  const FontRegistration(this.family, this.assets);
 
-Future<void> _overrideCupertinoFontsWithRoboto() async {
-  final root = flutterSdkRoot().absolute.path;
-
-  final materialFontsDir = Directory(
-    '$root/bin/cache/artifacts/material_fonts/',
-  );
-
-  final existingFonts = materialFontsDir
-      .listSync()
-      .whereType<File>()
-      .where(
-        (font) => fontFormats.any((element) => font.path.endsWith(element)),
-      )
-      .toList();
-
-  final robotoFonts = existingFonts
-      .where((font) {
-        final name = basename(font.path).toLowerCase();
-        return name.startsWith('Roboto-'.toLowerCase());
-      })
-      .map((file) => file.path)
-      .toList();
-  if (robotoFonts.isEmpty) {
-    debugPrint("Warning: No Roboto font found in SDK");
-  }
-  await loadFont('CupertinoSystemText', robotoFonts);
-  await loadFont('CupertinoSystemDisplay', robotoFonts);
-}
-
-Future<void> _overrideCupertinoFontsWithFamily(String fontFamily) async {
-  final fontManifestContent = await maybeRunAsync(
-    () => rootBundle.loadString('FontManifest.json'),
-  );
-
-  if (fontManifestContent == null || fontManifestContent.isEmpty) {
-    debugPrint(
-      'Warning: Could not load FontManifest.json to find "$fontFamily" fonts.',
-    );
-    return;
-  }
-
-  final entries = _parseFontManifest(fontManifestContent);
-  final assets = entries
-      .where((e) => e.$1 == fontFamily || e.$1.endsWith('/$fontFamily'))
-      .expand((e) => e.$2)
-      .toList();
-
-  if (assets.isEmpty) {
-    debugPrint(
-      'Warning: No font assets found for "$fontFamily". '
-      'Make sure it is declared in your pubspec.yaml.',
-    );
-    return;
-  }
-
-  await loadFont('CupertinoSystemText', assets);
-  await loadFont('CupertinoSystemDisplay', assets);
-}
-
-Future<void> _loadMacOSFonts() async {
-  if (!Platform.isMacOS) {
-    throw _MacOsFontLoadException(
-      '_loadMacOSFonts called on non-macOS platform',
-    );
-  }
-
-  final base = Directory('/Library/Fonts');
-
-  final sfProTextFonts = base
-      .listSync(recursive: true)
-      .whereType<File>()
-      .where((file) => file.isSFProTextFont)
-      .map((file) => file.path)
-      .toList();
-
-  final sfProDisplayFonts = base
-      .listSync(recursive: true)
-      .whereType<File>()
-      .where((file) => file.isSFProDisplayFont)
-      .map((file) => file.path)
-      .toList();
-
-  if (sfProTextFonts.isEmpty || sfProDisplayFonts.isEmpty) {
-    debugPrint(
-      "You are on macOS but no SF Pro fonts were found in "
-      "/Library/Fonts. Please install them from Apple's developer site: https://developer.apple.com/fonts/",
-    );
-
-    throw _MacOsFontLoadException('SF Pro fonts not found on macOS');
-  }
-
-  await loadFont('CupertinoSystemText', sfProTextFonts);
-  await loadFont('CupertinoSystemDisplay', sfProDisplayFonts);
-}
-
-extension on File {
-  bool get isFont {
-    final lower = path.toLowerCase();
-    return fontFormats.any(lower.endsWith);
-  }
-
-  bool get isRobotoFont {
-    if (!isFont) {
-      return false;
-    }
-    final name = basename(path).toLowerCase();
-    return name.startsWith('roboto-');
-  }
-
-  bool get isRobotoCondensedFont {
-    if (!isFont) {
-      return false;
-    }
-    final name = basename(path).toLowerCase();
-    return name.startsWith('robotocondensed-');
-  }
-
-  bool get isMaterialIconsFont {
-    if (!isFont) {
-      return false;
-    }
-    final name = basename(path).toLowerCase();
-    return name.startsWith('materialicons-');
-  }
-
-  bool get isSFProTextFont {
-    if (!isFont) {
-      return false;
-    }
-    final name = basename(path).toLowerCase();
-    return name.startsWith('sf-pro-text');
-  }
-
-  bool get isSFProDisplayFont {
-    if (!isFont) {
-      return false;
-    }
-    final name = basename(path).toLowerCase();
-    return name.startsWith('sf-pro-display');
-  }
-}
-
-class _MacOsFontLoadException implements Exception {
-  _MacOsFontLoadException(this.message);
-
-  final String message;
+  final String family;
+  final List<String> assets;
 
   @override
-  String toString() => 'MacOsFontLoadException: $message';
+  bool operator ==(Object other) =>
+      other is FontRegistration &&
+      family == other.family &&
+      listEquals(assets, other.assets);
+
+  @override
+  int get hashCode => Object.hash(family, Object.hashAll(assets));
 }
+
+/// A decoded family in Flutter's generated font manifest.
+@immutable
+@internal
+class FontManifestEntry {
+  const FontManifestEntry(this.family, this.assets);
+
+  final String family;
+  final List<String> assets;
+}
+
+/// Material families bundled in a Flutter SDK.
+@immutable
+@internal
+class MaterialFontInventory {
+  const MaterialFontInventory({
+    required this.roboto,
+    required this.robotoCondensed,
+    required this.materialIcons,
+  });
+
+  final List<String> roboto;
+  final List<String> robotoCondensed;
+  final List<String> materialIcons;
+}
+
+/// Groups supported files by their SDK family naming conventions.
+@internal
+MaterialFontInventory discoverMaterialFonts(Iterable<String> paths) {
+  final roboto = <String>[];
+  final condensed = <String>[];
+  final icons = <String>[];
+
+  for (final path in paths) {
+    if (!_hasSupportedExtension(path)) continue;
+    final name = basename(path).toLowerCase();
+    if (name.startsWith('roboto-')) {
+      roboto.add(path);
+    } else if (name.startsWith('robotocondensed-')) {
+      condensed.add(path);
+    } else if (name.startsWith('materialicons')) {
+      icons.add(path);
+    }
+  }
+
+  return MaterialFontInventory(
+    roboto: roboto,
+    robotoCondensed: condensed,
+    materialIcons: icons,
+  );
+}
+
+/// Decodes Flutter's generated `FontManifest.json`.
+@internal
+List<FontManifestEntry> decodeFontManifest(String content) {
+  if (content.trim().isEmpty) return const [];
+
+  final decoded = jsonDecode(content);
+  if (decoded is! List<Object?>) {
+    throw const FormatException('FontManifest.json must contain a list.');
+  }
+
+  return [
+    for (final item in decoded)
+      if (item case {'family': final String family, 'fonts': final List fonts})
+        FontManifestEntry(family, [
+          for (final font in fonts)
+            if (font case {'asset': final String asset}) asset,
+        ]),
+  ];
+}
+
+/// Expands package fonts into the names Flutter may use at runtime.
+@internal
+List<FontRegistration> fontRegistrationsForManifest(
+  Iterable<FontManifestEntry> entries,
+) {
+  final registrations = <FontRegistration>[];
+  for (final entry in entries) {
+    final packageAsset = entry.assets.where(_isPackageAsset).firstOrNull;
+    if (packageAsset == null) {
+      registrations.add(FontRegistration(entry.family, entry.assets));
+      continue;
+    }
+
+    final segments = packageAsset.split('/');
+    final package = segments.length > 1 ? segments[1] : null;
+    if (package == null || package.isEmpty) {
+      registrations.add(FontRegistration(entry.family, entry.assets));
+      continue;
+    }
+
+    final unqualifiedFamily = entry.family.split('/').last;
+    registrations
+      ..add(FontRegistration(unqualifiedFamily, entry.assets))
+      ..add(
+        FontRegistration(
+          'packages/$package/$unqualifiedFamily',
+          entry.assets,
+        ),
+      );
+  }
+  return registrations;
+}
+
+/// Returns every manifest asset matching an unqualified family name.
+@internal
+List<String> fontAssetsForFamily(
+  Iterable<FontManifestEntry> entries,
+  String family,
+) => [
+  for (final entry in entries)
+    if (entry.family == family || entry.family.endsWith('/$family'))
+      ...entry.assets,
+];
+
+/// Coordinates SDK, manifest, and Cupertino font registration.
+@internal
+class FontLoadingOrchestrator {
+  FontLoadingOrchestrator({
+    required this.sdkRoot,
+    required this.isMacOS,
+    required this.readManifest,
+    required this.listFontFiles,
+    required this.loadFamily,
+    this.log = debugPrint,
+  });
+
+  final Directory Function() sdkRoot;
+  final bool isMacOS;
+  final Future<String?> Function() readManifest;
+  final _DirectoryReader listFontFiles;
+  final Future<void> Function(String family, List<String> paths) loadFamily;
+  final void Function(String message) log;
+
+  bool _loaded = false;
+
+  Future<void> load([
+    CupertinoFontConfig cupertinoFonts = const CupertinoFontConfig.override(),
+  ]) async {
+    if (_loaded) return;
+
+    final materialDirectory = Directory(
+      join(
+        sdkRoot().absolute.path,
+        'bin',
+        'cache',
+        'artifacts',
+        'material_fonts',
+      ),
+    );
+    final material = discoverMaterialFonts(
+      listFontFiles(materialDirectory, recursive: false),
+    );
+    await _registerMaterialFonts(material);
+
+    final manifest = decodeFontManifest(await readManifest() ?? '');
+    for (final registration in fontRegistrationsForManifest(manifest)) {
+      await loadFamily(registration.family, registration.assets);
+    }
+
+    await _configureCupertino(cupertinoFonts, material, manifest);
+    _loaded = true;
+  }
+
+  Future<void> _registerMaterialFonts(MaterialFontInventory material) async {
+    await loadFamily('Roboto', material.roboto);
+    await loadFamily('RobotoCondensed', material.robotoCondensed);
+    await loadFamily('MaterialIcons', material.materialIcons);
+  }
+
+  Future<void> _configureCupertino(
+    CupertinoFontConfig configuration,
+    MaterialFontInventory material,
+    List<FontManifestEntry> manifest,
+  ) async {
+    switch (configuration) {
+      case _OverrideCupertinoFonts(:final fontFamily):
+        await _registerCupertinoOverride(fontFamily, material, manifest);
+      case _MacOsCupertinoFonts(:final fallbackOverride):
+        final systemFonts = isMacOS ? _findMacOsSystemFonts() : null;
+        if (systemFonts != null) {
+          await loadFamily('CupertinoSystemText', systemFonts.text);
+          await loadFamily('CupertinoSystemDisplay', systemFonts.display);
+          return;
+        }
+        if (fallbackOverride == null) {
+          throw StateError(
+            'CupertinoFontConfig.fromMacOsSystemFonts() could not find both '
+            'SF Pro Text and SF Pro Display in /Library/Fonts. Install them '
+            'from https://developer.apple.com/fonts/ or configure a fallback.',
+          );
+        }
+        await _registerCupertinoOverride(
+          fallbackOverride,
+          material,
+          manifest,
+        );
+    }
+  }
+
+  Future<void> _registerCupertinoOverride(
+    String family,
+    MaterialFontInventory material,
+    List<FontManifestEntry> manifest,
+  ) async {
+    final assets = family == 'Roboto'
+        ? material.roboto
+        : fontAssetsForFamily(manifest, family);
+    if (assets.isEmpty) {
+      log(
+        'Warning: No font assets found for "$family". '
+        'Make sure it is declared in pubspec.yaml.',
+      );
+      return;
+    }
+    await loadFamily('CupertinoSystemText', assets);
+    await loadFamily('CupertinoSystemDisplay', assets);
+  }
+
+  _MacOsSystemFonts? _findMacOsSystemFonts() {
+    final candidates = listFontFiles(
+      Directory('/Library/Fonts'),
+      recursive: true,
+    );
+    final text = <String>[];
+    final display = <String>[];
+    for (final path in candidates) {
+      if (!_hasSupportedExtension(path)) continue;
+      final name = basename(path).toLowerCase();
+      if (name.startsWith('sf-pro-text')) {
+        text.add(path);
+      } else if (name.startsWith('sf-pro-display')) {
+        display.add(path);
+      }
+    }
+    if (text.isEmpty || display.isEmpty) return null;
+    return _MacOsSystemFonts(text: text, display: display);
+  }
+}
+
+class _MacOsSystemFonts {
+  const _MacOsSystemFonts({required this.text, required this.display});
+
+  final List<String> text;
+  final List<String> display;
+}
+
+bool _hasSupportedExtension(String path) =>
+    supportedFontExtensions.contains(extension(path).toLowerCase());
+
+bool _isPackageAsset(String path) => path.startsWith('packages/');
+
+List<String> _listFiles(Directory directory, {required bool recursive}) =>
+    directory
+        .listSync(recursive: recursive)
+        .whereType<File>()
+        .map((file) => file.path)
+        .toList();
+
+Future<ByteData> _readFile(String path) async {
+  final bytes = await File(path).readAsBytes();
+  return bytes.buffer.asByteData(bytes.offsetInBytes, bytes.lengthInBytes);
+}
+
+Future<void> _registerFontFamily(
+  String family,
+  List<ByteData> fonts,
+) async {
+  final loader = FontLoader(family);
+  for (final font in fonts) {
+    loader.addFont(Future.value(font));
+  }
+  await loader.load();
+}
+
+final _defaultBinaryLoader = FontBinaryLoader(
+  fileExists: (path) => File(path).existsSync(),
+  readFile: _readFile,
+  readBundle: rootBundle.load,
+  register: _registerFontFamily,
+  runAsync: maybeRunAsync,
+);
+
+final _defaultFontLoading = FontLoadingOrchestrator(
+  sdkRoot: flutterSdkRoot,
+  isMacOS: Platform.isMacOS,
+  readManifest: () => maybeRunAsync(
+    () => rootBundle.loadString('FontManifest.json'),
+  ),
+  listFontFiles: _listFiles,
+  loadFamily: loadFont,
+);

--- a/packages/snaptest/lib/src/font_loading.dart
+++ b/packages/snaptest/lib/src/font_loading.dart
@@ -1,11 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:snaptest/src/flutter_sdk_root.dart';
 import 'package:snaptest/src/snap.dart';
@@ -128,21 +126,6 @@ Future<void> loadFonts({
 Future<void> loadFont(String family, List<String> fromPaths) =>
     _defaultBinaryLoader.load(family, fromPaths);
 
-typedef _AsyncScope =
-    Future<T?> Function<T>(
-      Future<T> Function() operation,
-    );
-typedef _FontRegistrar =
-    Future<void> Function(
-      String family,
-      List<ByteData> fonts,
-    );
-typedef _DirectoryReader =
-    List<String> Function(
-      Directory directory, {
-      required bool recursive,
-    });
-
 /// Reads font bytes and submits one complete family to Flutter.
 ///
 /// The collaborators are injectable so path selection and registration can be
@@ -161,8 +144,8 @@ class FontBinaryLoader {
   final bool Function(String path) fileExists;
   final Future<ByteData> Function(String path) readFile;
   final Future<ByteData> Function(String path) readBundle;
-  final _FontRegistrar register;
-  final _AsyncScope runAsync;
+  final Future<void> Function(String family, List<ByteData> fonts) register;
+  final Future<T?> Function<T>(Future<T> Function() operation) runAsync;
   final void Function(String message) log;
 
   Future<void> load(String family, List<String> paths) async {
@@ -266,7 +249,10 @@ List<FontManifestEntry> decodeFontManifest(String content) {
 
   return [
     for (final item in decoded)
-      if (item case {'family': final String family, 'fonts': final List fonts})
+      if (item case {
+        'family': final String family,
+        'fonts': final List<Object?> fonts,
+      })
         FontManifestEntry(family, [
           for (final font in fonts)
             if (font case {'asset': final String asset}) asset,
@@ -333,7 +319,11 @@ class FontLoadingOrchestrator {
   final Directory Function() sdkRoot;
   final bool isMacOS;
   final Future<String?> Function() readManifest;
-  final _DirectoryReader listFontFiles;
+  final List<String> Function(
+    Directory directory, {
+    required bool recursive,
+  })
+  listFontFiles;
   final Future<void> Function(String family, List<String> paths) loadFamily;
   final void Function(String message) log;
 

--- a/packages/snaptest/lib/src/font_loading.dart
+++ b/packages/snaptest/lib/src/font_loading.dart
@@ -149,14 +149,14 @@ typedef _DirectoryReader =
 /// tested without mutating Flutter's process-wide font collection.
 @internal
 class FontBinaryLoader {
-  const FontBinaryLoader({
+  FontBinaryLoader({
     required this.fileExists,
     required this.readFile,
     required this.readBundle,
     required this.register,
     required this.runAsync,
-    this.log = debugPrint,
-  });
+    void Function(String message)? log,
+  }) : log = log ?? debugPrint;
 
   final bool Function(String path) fileExists;
   final Future<ByteData> Function(String path) readFile;
@@ -327,8 +327,8 @@ class FontLoadingOrchestrator {
     required this.readManifest,
     required this.listFontFiles,
     required this.loadFamily,
-    this.log = debugPrint,
-  });
+    void Function(String message)? log,
+  }) : log = log ?? debugPrint;
 
   final Directory Function() sdkRoot;
   final bool isMacOS;

--- a/packages/snaptest/pubspec.yaml
+++ b/packages/snaptest/pubspec.yaml
@@ -1,6 +1,6 @@
 name: snaptest
 description: Snap photos in your widget tests.
-version: 1.0.0-dev.3
+version: 1.0.0-dev.4
 resolution: workspace
 topics: ["testing", "golden", "screenshots", "automation"]
 
@@ -21,7 +21,7 @@ dev_dependencies:
 
 dependencies:
   args: ^2.4.0
-  characters: # will be pinned by SDK
+  characters: ^1.4.1
   device_frame: ">=1.0.0 <2.0.0"
   equatable: ">=2.0.0 <3.0.0"
   flutter:

--- a/packages/snaptest/test/src/flutter_sdk_root_test.dart
+++ b/packages/snaptest/test/src/flutter_sdk_root_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snaptest/src/flutter_sdk_root.dart';
+
+void main() {
+  group('flutterSdkRootFromExecutable', () {
+    test('derives a POSIX SDK root from flutter_tester', () {
+      expect(
+        flutterSdkRootFromExecutable(
+          '/opt/flutter/bin/cache/artifacts/engine/linux-x64/flutter_tester',
+          windows: false,
+        ).path,
+        '/opt/flutter',
+      );
+    });
+
+    test('derives a Windows SDK root with either separator style', () {
+      expect(
+        flutterSdkRootFromExecutable(
+          r'C:\tools\flutter\bin\cache\artifacts\engine\windows-x64\flutter_tester.exe',
+          windows: true,
+        ).path,
+        r'C:\tools\flutter',
+      );
+      expect(
+        flutterSdkRootFromExecutable(
+          'C:/tools/flutter/bin/cache/artifacts/engine/windows-x64/flutter_tester.exe',
+          windows: true,
+        ).path,
+        r'C:\tools\flutter',
+      );
+    });
+
+    test('rejects executables outside a Flutter SDK cache', () {
+      expect(
+        () => flutterSdkRootFromExecutable(
+          '/usr/local/bin/dart',
+          windows: false,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/packages/snaptest/test/src/font_loading_test.dart
+++ b/packages/snaptest/test/src/font_loading_test.dart
@@ -1,0 +1,305 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snaptest/src/font_loading.dart';
+import 'package:snaptest/src/snap.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FontBinaryLoader', () {
+    test(
+      'uses the filesystem for existing paths and bundle otherwise',
+      () async {
+        final reads = <String>[];
+        final registrations = <(String, List<int>)>[];
+        final loader = FontBinaryLoader(
+          fileExists: (path) => path == '/fonts/on-disk.ttf',
+          readFile: (path) async {
+            reads.add('file:$path');
+            return _bytes(1);
+          },
+          readBundle: (path) async {
+            reads.add('bundle:$path');
+            return _bytes(2);
+          },
+          register: (family, fonts) async {
+            registrations.add((
+              family,
+              fonts.map((data) => data.getUint8(0)).toList(),
+            ));
+          },
+          runAsync: <T>(operation) => operation(),
+        );
+
+        await loader.load('Example', [
+          '/fonts/on-disk.ttf',
+          'assets/in-bundle.otf',
+        ]);
+
+        expect(reads, [
+          'file:/fonts/on-disk.ttf',
+          'bundle:assets/in-bundle.otf',
+        ]);
+        expect(registrations, [
+          ('Example', [1, 2]),
+        ]);
+      },
+    );
+
+    test('does nothing for an empty path list', () async {
+      var enteredAsyncScope = false;
+      var registered = false;
+      final loader = FontBinaryLoader(
+        fileExists: (_) => false,
+        readFile: (_) => throw UnimplementedError(),
+        readBundle: (_) => throw UnimplementedError(),
+        register: (_, _) async => registered = true,
+        runAsync: <T>(operation) async {
+          enteredAsyncScope = true;
+          return operation();
+        },
+      );
+
+      await loader.load('Empty', const []);
+
+      expect(enteredAsyncScope, isFalse);
+      expect(registered, isFalse);
+    });
+
+    testWidgets('can execute while already inside runAsync', (tester) async {
+      var registered = false;
+      final loader = FontBinaryLoader(
+        fileExists: (_) => false,
+        readFile: (_) => throw UnimplementedError(),
+        readBundle: (_) async => _bytes(7),
+        register: (_, fonts) async {
+          registered = fonts.single.getUint8(0) == 7;
+        },
+        runAsync: maybeRunAsync,
+      );
+
+      await tester.runAsync(
+        () => loader.load('Nested', const ['assets/font.ttf']),
+      );
+
+      expect(registered, isTrue);
+    });
+  });
+
+  group('material font discovery', () {
+    test('selects supported Roboto, condensed, and icon files only', () {
+      final fonts = discoverMaterialFonts([
+        '/sdk/Roboto-Regular.ttf',
+        '/sdk/Roboto-Bold.OTF',
+        '/sdk/Roboto.txt',
+        '/sdk/RobotoCondensed-Regular.ttf',
+        '/sdk/MaterialIcons-Regular.otf',
+        '/sdk/MaterialIconsOutlined-Regular.ttf',
+        '/sdk/Other.ttf',
+      ]);
+
+      expect(fonts.roboto, [
+        '/sdk/Roboto-Regular.ttf',
+        '/sdk/Roboto-Bold.OTF',
+      ]);
+      expect(fonts.robotoCondensed, [
+        '/sdk/RobotoCondensed-Regular.ttf',
+      ]);
+      expect(fonts.materialIcons, [
+        '/sdk/MaterialIcons-Regular.otf',
+        '/sdk/MaterialIconsOutlined-Regular.ttf',
+      ]);
+    });
+  });
+
+  group('FontManifest', () {
+    test('keeps app families and aliases package families', () {
+      final entries = decodeFontManifest('''
+[
+  {
+    "family": "AppFont",
+    "fonts": [{"asset": "assets/app.ttf"}]
+  },
+  {
+    "family": "PackageFont",
+    "fonts": [{"asset": "packages/toolkit/fonts/package.ttf"}]
+  },
+  {
+    "family": "packages/widgets/QualifiedFont",
+    "fonts": [{"asset": "packages/widgets/fonts/qualified.ttf"}]
+  }
+]
+''');
+
+      expect(fontRegistrationsForManifest(entries), [
+        const FontRegistration('AppFont', ['assets/app.ttf']),
+        const FontRegistration(
+          'PackageFont',
+          ['packages/toolkit/fonts/package.ttf'],
+        ),
+        const FontRegistration(
+          'packages/toolkit/PackageFont',
+          ['packages/toolkit/fonts/package.ttf'],
+        ),
+        const FontRegistration(
+          'QualifiedFont',
+          ['packages/widgets/fonts/qualified.ttf'],
+        ),
+        const FontRegistration(
+          'packages/widgets/QualifiedFont',
+          ['packages/widgets/fonts/qualified.ttf'],
+        ),
+      ]);
+    });
+
+    test('finds both app and package-qualified family names', () {
+      const entries = [
+        FontManifestEntry('Custom', ['assets/custom.ttf']),
+        FontManifestEntry(
+          'packages/theme/Custom',
+          ['packages/theme/custom-bold.ttf'],
+        ),
+      ];
+
+      expect(fontAssetsForFamily(entries, 'Custom'), [
+        'assets/custom.ttf',
+        'packages/theme/custom-bold.ttf',
+      ]);
+    });
+  });
+
+  group('FontLoadingOrchestrator', () {
+    test('is idempotent after a successful load', () async {
+      final harness = _Harness();
+      final orchestrator = harness.create();
+
+      await orchestrator.load();
+      final firstLoad = List.of(harness.loads);
+      await orchestrator.load();
+
+      expect(harness.loads, firstLoad);
+      expect(harness.manifestReads, 1);
+      expect(harness.directoryReads, 1);
+    });
+
+    test('applies a custom Cupertino override from the manifest', () async {
+      final harness = _Harness(
+        manifest: '''
+[
+  {
+    "family": "Inter",
+    "fonts": [{"asset": "assets/inter.ttf"}]
+  }
+]
+''',
+      );
+
+      await harness.create().load(
+        const CupertinoFontConfig.override(fontFamily: 'Inter'),
+      );
+
+      expect(
+        harness.loads,
+        contains(
+          const FontRegistration('CupertinoSystemText', ['assets/inter.ttf']),
+        ),
+      );
+      expect(
+        harness.loads,
+        contains(
+          const FontRegistration('CupertinoSystemDisplay', [
+            'assets/inter.ttf',
+          ]),
+        ),
+      );
+    });
+
+    test(
+      'uses the configured fallback when macOS fonts are unavailable',
+      () async {
+        final harness = _Harness(
+          manifest: '''
+[
+  {
+    "family": "Fallback",
+    "fonts": [{"asset": "assets/fallback.ttf"}]
+  }
+]
+''',
+        );
+
+        await harness.create().load(
+          const CupertinoFontConfig.fromMacOsSystemFonts(
+            fallbackOverride: 'Fallback',
+          ),
+        );
+
+        expect(
+          harness.loads,
+          containsAll([
+            const FontRegistration(
+              'CupertinoSystemText',
+              ['assets/fallback.ttf'],
+            ),
+            const FontRegistration(
+              'CupertinoSystemDisplay',
+              ['assets/fallback.ttf'],
+            ),
+          ]),
+        );
+      },
+    );
+
+    test('throws without a Cupertino fallback off macOS', () async {
+      final harness = _Harness();
+
+      await expectLater(
+        harness.create().load(
+          const CupertinoFontConfig.fromMacOsSystemFonts(),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}
+
+ByteData _bytes(int value) => Uint8List.fromList([value]).buffer.asByteData();
+
+class _Harness {
+  _Harness({
+    this.manifest = '[]',
+    this.isMacOS = false,
+  });
+
+  final String manifest;
+  final bool isMacOS;
+  final loads = <FontRegistration>[];
+  var manifestReads = 0;
+  var directoryReads = 0;
+
+  FontLoadingOrchestrator create() => FontLoadingOrchestrator(
+    sdkRoot: () => Directory('/fake/flutter'),
+    isMacOS: isMacOS,
+    readManifest: () async {
+      manifestReads++;
+      return manifest;
+    },
+    listFontFiles: (directory, {required recursive}) {
+      directoryReads++;
+      if (directory.path.endsWith('material_fonts')) {
+        return [
+          '${directory.path}/Roboto-Regular.ttf',
+          '${directory.path}/RobotoCondensed-Regular.ttf',
+          '${directory.path}/MaterialIcons-Regular.otf',
+        ];
+      }
+      return const [];
+    },
+    loadFamily: (family, paths) async {
+      loads.add(FontRegistration(family, paths));
+    },
+    log: (_) {},
+  );
+}

--- a/packages/snaptest/test/src/font_loading_test.dart
+++ b/packages/snaptest/test/src/font_loading_test.dart
@@ -42,9 +42,9 @@ void main() {
           'file:/fonts/on-disk.ttf',
           'bundle:assets/in-bundle.otf',
         ]);
-        expect(registrations, [
-          ('Example', [1, 2]),
-        ]);
+        expect(registrations, hasLength(1));
+        expect(registrations.single.$1, 'Example');
+        expect(registrations.single.$2, [1, 2]);
       },
     );
 

--- a/packages/snaptest/test/src/font_loading_test.dart
+++ b/packages/snaptest/test/src/font_loading_test.dart
@@ -252,6 +252,28 @@ void main() {
       },
     );
 
+    test('registers matching macOS text and display families', () async {
+      final harness = _Harness(isMacOS: true);
+
+      await harness.create().load(
+        const CupertinoFontConfig.fromMacOsSystemFonts(),
+      );
+
+      expect(
+        harness.loads,
+        containsAll([
+          const FontRegistration(
+            'CupertinoSystemText',
+            ['/Library/Fonts/SF-Pro-Text-Regular.otf'],
+          ),
+          const FontRegistration(
+            'CupertinoSystemDisplay',
+            ['/Library/Fonts/SF-Pro-Display-Regular.otf'],
+          ),
+        ]),
+      );
+    });
+
     test('throws without a Cupertino fallback off macOS', () async {
       final harness = _Harness();
 
@@ -276,8 +298,8 @@ class _Harness {
   final String manifest;
   final bool isMacOS;
   final loads = <FontRegistration>[];
-  var manifestReads = 0;
-  var directoryReads = 0;
+  int manifestReads = 0;
+  int directoryReads = 0;
 
   FontLoadingOrchestrator create() => FontLoadingOrchestrator(
     sdkRoot: () => Directory('/fake/flutter'),
@@ -293,6 +315,12 @@ class _Harness {
           '${directory.path}/Roboto-Regular.ttf',
           '${directory.path}/RobotoCondensed-Regular.ttf',
           '${directory.path}/MaterialIcons-Regular.otf',
+        ];
+      }
+      if (isMacOS && directory.path == '/Library/Fonts') {
+        return const [
+          '/Library/Fonts/SF-Pro-Text-Regular.otf',
+          '/Library/Fonts/SF-Pro-Display-Regular.otf',
         ];
       }
       return const [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

- prepares the MIT-licensed `snaptest` 1.0.0-dev.4 prerelease
- replaces the adapted font-loading implementation with a collaborator-driven orchestration model
- preserves the public `loadFonts`, `loadFont`, and `CupertinoFontConfig` APIs
- separates font byte acquisition, manifest decoding, SDK discovery, registration planning, and Cupertino selection
- adds focused behavioral coverage for those responsibilities and SDK-root discovery
- adds an explicit `characters` constraint required for warning-free publication

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes

## Validation

- focused font-loader and SDK-root suite — 14 tests passed
- complete `snaptest` suite — 51 tests passed
- `dart analyze --fatal-infos` — no issues
- `dart pub publish --dry-run` — 0 warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd3f5-fba0-7fe0-aead-cd358d70b4d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd3f5-fba0-7fe0-aead-cd358d70b4d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

