### PR TITLE
feat(heroine): rotation support.

### DIFF
--- a/packages/heroine/lib/src/flight_controller.dart
+++ b/packages/heroine/lib/src/flight_controller.dart
@@ -263,8 +263,13 @@ class _FlightController {
             controller.value.boundingBox.size.width / 2,
         width: controller.value.boundingBox.size.width,
         height: controller.value.boundingBox.size.height,
-        // TODO(timcreatedit): rotate here
-        child: child!,
+        // The rotation rides the same spring as the rect, so a hero leaving
+        // a tilted resting place untwists (or twists back) in step with its
+        // travel.
+        child: Transform.rotate(
+          angle: controller.value.rotation,
+          child: child,
+        ),
       ),
       child: IgnorePointer(
         // TODO(timcreatedit): allow configuring this

--- a/packages/heroine/lib/src/flight_spec.dart
+++ b/packages/heroine/lib/src/flight_spec.dart
@@ -148,6 +148,12 @@ class _FlightSpec {
 
   /// Computes the bounding box for a context's render object,
   /// in an ancestor context's coordinate space.
+  ///
+  /// The transform's 2D linear part is decomposed into rotation and per-axis
+  /// scale rather than flattened with [MatrixUtils.transformRect]: a hero
+  /// under a `Transform.rotate` ancestor would otherwise report the inflated
+  /// axis-aligned bounding box of its tilted self, and the flight would land
+  /// on a rect that is both too large and untilted.
   static HeroineLocation _locationFor(
     _HeroineState state,
     BuildContext? ancestorContext,
@@ -159,13 +165,29 @@ class _FlightSpec {
       'RenderObject must have a finite size to be used as a hero',
     );
 
-    final rect = MatrixUtils.transformRect(
-      box.getTransformTo(ancestorContext?.findRenderObject()),
-      Offset.zero & box.size,
+    final transform =
+        box.getTransformTo(ancestorContext?.findRenderObject());
+
+    final m00 = transform.entry(0, 0);
+    final m10 = transform.entry(1, 0);
+    final m01 = transform.entry(0, 1);
+    final m11 = transform.entry(1, 1);
+    final rotation = math.atan2(m10, m00);
+    final scaleX = math.sqrt(m00 * m00 + m10 * m10);
+    final scaleY = math.sqrt(m01 * m01 + m11 * m11);
+
+    final center = MatrixUtils.transformPoint(
+      transform,
+      box.size.center(Offset.zero),
     );
 
-    // TODO(tim): find rotation here
-    return HeroineLocation(boundingBox: rect);
+    final rect = Rect.fromCenter(
+      center: center,
+      width: box.size.width * scaleX,
+      height: box.size.height * scaleY,
+    );
+
+    return HeroineLocation(boundingBox: rect, rotation: rotation);
   }
 
   @override

--- a/packages/heroine/lib/src/heroine_widget.dart
+++ b/packages/heroine/lib/src/heroine_widget.dart
@@ -172,9 +172,7 @@ class _HeroineState extends State<Heroine> with TickerProviderStateMixin {
     _motionController = MotionController(
       vsync: this,
       motion: spec.motion,
-      initialValue: HeroineLocation(
-        boundingBox: spec.fromHeroLocation.boundingBox,
-      ),
+      initialValue: spec.fromHeroLocation,
       converter: _HeroineLocationConverter(),
     )..addStatusListener(onSpringAnimationStatusChanged);
   }
@@ -327,18 +325,21 @@ class _HeroineState extends State<Heroine> with TickerProviderStateMixin {
           builder: (context, child) {
             return Transform.translate(
               offset: landing.offset,
-              child: SizedBox.fromSize(
-                size: landing.placeholderSize,
-                child: OverflowBox(
-                  maxHeight: double.infinity,
-                  maxWidth: double.infinity,
-                  child: Center(
-                    child: SizedBox.fromSize(
-                      size: Size(
-                        landing.sizeX,
-                        landing.sizeY,
+              child: Transform.rotate(
+                angle: landing.rotationDelta,
+                child: SizedBox.fromSize(
+                  size: landing.placeholderSize,
+                  child: OverflowBox(
+                    maxHeight: double.infinity,
+                    maxWidth: double.infinity,
+                    child: Center(
+                      child: SizedBox.fromSize(
+                        size: Size(
+                          landing.sizeX,
+                          landing.sizeY,
+                        ),
+                        child: child,
                       ),
-                      child: child,
                     ),
                   ),
                 ),
@@ -366,6 +367,7 @@ sealed class _Status {
 /// These happen while the routes are transitioning.
 abstract interface class _InFlight {
   _FlightSpec get spec;
+
   Size get placeholderSize;
 }
 
@@ -433,9 +435,28 @@ class _ToLanding extends _Status {
 
   final HeroineLocation target;
 
-  /// The current offset from the target center.
-  Offset get offset =>
-      controller.value.boundingBox.center - target.boundingBox.center;
+  /// The current offset from the target center, expressed in the destination
+  /// hero's local frame.
+  ///
+  /// The spring animates in global coordinates, but this widget renders
+  /// inside the destination's subtree under whatever rotation its ancestors
+  /// apply, so the global displacement is rotated back by the target's
+  /// resting rotation before being handed to [Transform.translate].
+  Offset get offset {
+    final delta =
+        controller.value.boundingBox.center - target.boundingBox.center;
+    if (target.rotation == 0) return delta;
+    final cos = math.cos(-target.rotation);
+    final sin = math.sin(-target.rotation);
+    return Offset(
+      delta.dx * cos - delta.dy * sin,
+      delta.dx * sin + delta.dy * cos,
+    );
+  }
+
+  /// How far the spring's rotation still is from the target's resting
+  /// rotation.
+  double get rotationDelta => controller.value.rotation - target.rotation;
 
   double get sizeX => controller.value.boundingBox.width;
 

--- a/packages/heroine/lib/src/heroines.dart
+++ b/packages/heroine/lib/src/heroines.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/heroine/test/src/rotated_heroine_test.dart
+++ b/packages/heroine/test/src/rotated_heroine_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heroine/heroine.dart';
+
+void main() {
+  group('Heroine under a rotated ancestor', () {
+    const tag = 'photo';
+    const tilt = 0.3;
+    const heroSize = 80.0;
+
+    // Settles much faster than the route transition, so sampling near the
+    // end of the route reads the flight's settled *target* rather than a
+    // point mid-air.
+    const motion = CupertinoMotion.smooth(
+      duration: Duration(milliseconds: 60),
+    );
+
+    Widget build() => MaterialApp(
+          navigatorObservers: [HeroineController()],
+          home: Scaffold(
+            body: Center(
+              child: Transform.rotate(
+                angle: tilt,
+                child: const Heroine(
+                  tag: tag,
+                  motion: motion,
+                  child: SizedBox.square(dimension: heroSize),
+                ),
+              ),
+            ),
+          ),
+        );
+
+    Widget page2() => const Scaffold(
+          body: Center(
+            child: Heroine(
+              tag: tag,
+              motion: motion,
+              child: SizedBox.square(dimension: 300),
+            ),
+          ),
+        );
+
+    testWidgets(
+        'a pop flies home to the true rect and tilt, '
+        'not the axis-aligned bounding box', (tester) async {
+      await tester.pumpWidget(build());
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      unawaited(
+        navigator.push(
+          PageRouteBuilder<void>(
+            pageBuilder: (context, animation, secondaryAnimation) => page2(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      navigator.pop();
+      await tester.pump();
+      // Frame by frame to just shy of the route completing: the overlay is
+      // still up, and the fast spring has already settled at its target.
+      for (var elapsed = 0; elapsed < 280; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // An 80×80 hero rotated by 0.3 rad has a ~100-wide axis-aligned
+      // bounding box; the flight must aim at the hero's own square instead.
+      final positioned = tester.widget<Positioned>(find.byType(Positioned));
+      expect(positioned.width, closeTo(heroSize, 1));
+      expect(positioned.height, closeTo(heroSize, 1));
+
+      // And the shuttle must arrive carrying the destination's resting tilt.
+      final rotate = tester.widget<Transform>(
+        find
+            .descendant(
+              of: find.byType(Positioned),
+              matching: find.byType(Transform),
+            )
+            .first,
+      );
+      final transform = rotate.transform;
+      expect(
+        math.atan2(transform.entry(1, 0), transform.entry(0, 0)),
+        closeTo(tilt, 0.01),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.getSize(find.byType(Heroine)),
+        const Size.square(heroSize),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes hero flights to and from a `Heroine` that sits under a rotated ancestor (for example a photo inside a tilted card drawn with `Transform.rotate`).

Previously, `_FlightSpec._locationFor` flattened the hero's transform with `MatrixUtils.transformRect`, so a rotated hero was measured as its axis-aligned bounding box: a rect that is both larger than the hero (about 25% wider for an 80x80 hero tilted 0.3 rad) and carries no rotation. The overlay shuttle was also positioned without any rotation. The result was a visible snap on landing: the shuttle arrived untilted and oversized, then the real widget appeared tilted at its true size. Both spots were already marked upstream (`TODO(tim): find rotation here` in `flight_spec.dart`, and `TODO(timcreatedit): rotate here` in `flight_controller.dart`), and `HeroineLocation.rotation` plus its motion converter already existed but were never fed.

This PR completes that support:

- `flight_spec.dart`: `_locationFor` decomposes the hero's transform into rotation and per-axis scale, and returns the hero's true rect (transformed center, scaled size) together with its rotation, instead of the inflated axis-aligned bounding box.
- `flight_controller.dart`: the overlay shuttle is wrapped in `Transform.rotate(angle: controller.value.rotation)`, so the tilt animates on the same spring as the position and size, in both flight directions.
- `heroine_widget.dart`: the motion controller's initial value keeps the source location's rotation (it was previously stripped), and the `_ToLanding` handoff now expresses the spring's residual offset in the destination's local frame (rotated back by the target's resting rotation) and applies the remaining rotation delta, which decays to zero as the spring settles. This keeps the overlay-to-tree handoff continuous for rotated destinations.
- `heroines.dart`: adds the `dart:math` import used by the decomposition.

Heroes with no rotated ancestors are unaffected: the decomposition yields rotation 0 and the exact same rect as before, and all existing tests pass unchanged.

Added `test/src/rotated_heroine_test.dart`, which pops back to a hero under `Transform.rotate(angle: 0.3)` and asserts that the settled flight target is the hero's own 80x80 rect (not the ~100 wide bounding box), that the shuttle arrives carrying the destination's resting tilt, and that the hero lays out at its natural size after the flight ends.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes

Notes on the checklist: no new public API is introduced (HeroineLocation.rotation already exists and is documented); the new private members (_ToLanding.rotationDelta, the reworked offset) carry doc comments anyway.