### PR TITLE
fix(fixed_ticker): only merge mutually compatible shared scheduler groups

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,11 +33,14 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.1' # keep in sync with .fvmrc
           channel: 'stable'
           cache: true
       
       - name: Ⓜ️ Set up Melos
         uses: bluefireteam/melos-action@v3
+        with:
+          melos-version: '7.4.0' # keep in sync with the melos constraint in pubspec.yaml
 
       - name: 🧪 Run Analyze
         run: melos run analyze
@@ -75,11 +78,14 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.1' # keep in sync with .fvmrc
           channel: 'stable'
           cache: true
 
       - name: Ⓜ️ Set up Melos
         uses: bluefireteam/melos-action@v3
+        with:
+          melos-version: '7.4.0' # keep in sync with the melos constraint in pubspec.yaml
 
       - name: 🔨 Generate
         run: melos run generate

--- a/packages/fixed_ticker/lib/src/fixed_ticker.dart
+++ b/packages/fixed_ticker/lib/src/fixed_ticker.dart
@@ -210,12 +210,19 @@ class _SharedTickScheduler {
     final compatibleGroups = _groups
         .where((candidate) => candidate.canUse(interval))
         .toList();
-    final group = compatibleGroups.firstOrNull;
-    final selectedGroup = group ?? (_SharedTickGroup(this, interval)..start());
+    final selectedGroup =
+        compatibleGroups.firstOrNull ??
+        (_SharedTickGroup(this, interval)..start());
     _groups.add(selectedGroup);
     selectedGroup.prepareBase(interval);
     for (final compatibleGroup in compatibleGroups.skip(1)) {
-      selectedGroup.absorb(compatibleGroup);
+      // A rate can be compatible with two groups whose bases are not
+      // compatible with each other (e.g. 10ms, 15ms, and a new 30ms rate).
+      // Interval compatibility is not transitive, so only absorb groups that
+      // can share a common base without breaking the cadence invariant.
+      if (selectedGroup.canAbsorb(compatibleGroup)) {
+        selectedGroup.absorb(compatibleGroup);
+      }
     }
     selectedGroup.add(ticker, interval);
     _tickerGroups[ticker] = selectedGroup;
@@ -251,6 +258,22 @@ class _SharedTickGroup {
     final effectiveBase = _pendingBaseInterval ?? baseInterval;
     return _harmonicMultiple(interval, effectiveBase) != null ||
         _harmonicMultiple(effectiveBase, interval) != null;
+  }
+
+  /// Whether [other] can be merged into this group without breaking the
+  /// invariant that every member interval is an integer multiple of the
+  /// group's base.
+  ///
+  /// This holds exactly when one group's effective base (including a pending
+  /// rebase) is an integer multiple of the other's: the faster base then
+  /// divides every member interval of both groups. Groups whose bases are
+  /// unrelated (e.g. 10ms and 15ms) must stay separate even when a third rate
+  /// (e.g. 30ms) is compatible with both.
+  bool canAbsorb(_SharedTickGroup other) {
+    final base = _pendingBaseInterval ?? baseInterval;
+    final otherBase = other._pendingBaseInterval ?? other.baseInterval;
+    return _harmonicMultiple(otherBase, base) != null ||
+        _harmonicMultiple(base, otherBase) != null;
   }
 
   Duration? intervalFor(FixedTicker ticker) {

--- a/packages/fixed_ticker/test/shared_scheduler_adversarial_test.dart
+++ b/packages/fixed_ticker/test/shared_scheduler_adversarial_test.dart
@@ -221,6 +221,65 @@ void main() {
       }
     });
 
+    testWidgets(
+      'a rate compatible with two groups joins one without merging them', (
+      tester,
+    ) async {
+      const tenMs = Duration(milliseconds: 10);
+      const fifteenMs = Duration(milliseconds: 15);
+      const thirtyMs = Duration(milliseconds: 30);
+      final tenElapsed = <Duration>[];
+      final fifteenElapsed = <Duration>[];
+      final thirtyElapsed = <Duration>[];
+      final ten = FixedTicker(tenElapsed.add, interval: tenMs);
+      final fifteen = FixedTicker(fifteenElapsed.add, interval: fifteenMs);
+      final thirty = FixedTicker(thirtyElapsed.add, interval: thirtyMs);
+      try {
+        unawaited(ten.start());
+        await tester.pump();
+        unawaited(fifteen.start());
+        await tester.pump();
+        unawaited(thirty.start());
+        await tester.pump();
+        tenElapsed.clear();
+        fifteenElapsed.clear();
+        thirtyElapsed.clear();
+
+        // Window of 65ms after all three tickers are running. The 10ms and
+        // 15ms groups are mutually incompatible, so the 30ms rate can belong
+        // to at most one of them.
+        for (var i = 0; i < 13; i++) {
+          await tester.pump(const Duration(milliseconds: 5));
+        }
+
+        // Regression: joining the 30ms rate used to crash with a null check
+        // error while trying to absorb the 15ms group into the 10ms group.
+        expect(tenElapsed, isNotEmpty);
+        expect(fifteenElapsed, isNotEmpty);
+        expect(thirtyElapsed, hasLength(2));
+
+        // The 30ms ticker must keep its own cadence ...
+        final thirtyDeltas = [
+          for (var i = 1; i < thirtyElapsed.length; i++)
+            thirtyElapsed[i] - thirtyElapsed[i - 1],
+        ];
+        expect(thirtyDeltas, everyElement(thirtyMs));
+
+        // ... aligned with the 10ms group it joined ...
+        final tenBoundaries = tenElapsed.toSet();
+        expect(tenBoundaries.containsAll(thirtyElapsed), isTrue);
+
+        // ... while the unrelated 15ms group keeps its independent cadence.
+        final fifteenDeltas = [
+          for (var i = 1; i < fifteenElapsed.length; i++)
+            fifteenElapsed[i] - fifteenElapsed[i - 1],
+        ];
+        expect(fifteenDeltas, everyElement(fifteenMs));
+      } finally {
+        _disposeTickers([ten, fifteen, thirty]);
+      }
+    });
+
     testWidgets('removing the fastest subscriber preserves slower cadence', (
       tester,
     ) async {


### PR DESCRIPTION
## Problem

#300 taught fixed-rate tickers to share a phase-aligned scheduler. Interval compatibility, however, is **not transitive**: a 30 ms rate is a harmonic multiple of both a 10 ms group and a 15 ms group, which are incompatible with each other.

When a ticker subscribed to such a rate, `_SharedTickScheduler.subscribe` picked the first compatible group and unconditionally `absorb`ed every other compatible group. The absorbed group's intervals were then matched against the selected group's base, producing a null harmonic multiple and crashing:

```
Null check operator used on a null value
#0  _SharedTickGroup._absorbNow  (fixed_ticker.dart:297)
#1  _SharedTickGroup.absorb      (fixed_ticker.dart:280)
#2  _SharedTickScheduler.subscribe
#3  FixedTicker._startTimer
#4  FixedTicker.scheduleTick
#5  Ticker.start
```

Real-world trigger: a 100 fps ticker and a ~66 fps ticker already running, then a 33 fps ticker starts.

## Fix

Gate absorption behind a mutual base-compatibility check (`_SharedTickGroup.canAbsorb`): two groups may merge exactly when one group's effective base (including a pending rebase) is an integer multiple of the other's. The faster base then divides every member interval of both groups, so the group invariant ("every member interval is an integer multiple of the base") survives the merge.

Rates that are compatible with two mutually incompatible groups now simply join one of them; the other group keeps its independent phase — matching the documented "shared when framerates line up" behavior. No changelog entry of its own, since the feature it fixes is still unreleased.

## Proof

- New adversarial regression test (`a rate compatible with two groups joins one without merging them`): starts 10 ms and 15 ms tickers (two unrelated groups), then a 30 ms ticker. On the merged code it crashes with the exact `Null check operator` error above; with this fix it passes and verifies the 30 ms ticker keeps its cadence, aligns with the 10 ms group it joined, and the 15 ms group keeps its independent cadence.
- Full package suite passes, `dart analyze --fatal-infos` clean.

## 2nd commit: why CI needed a toolchain pin

The initial CI run failed on code this PR never touched: CI floats `channel: stable` and the latest melos, and since main's last green run the toolchain moved to Flutter 3.47.2 / melos 8.6.0. The new analyzer tightened a lint on pre-existing `fixed_ticker` code, and melos 8 now auto-edits every `analysis_options.yaml`, failing the code-generation check. Rather than churn the whole repo to satisfy a floating toolchain, the second commit pins CI to the versions the repo actually develops with: Flutter `3.44.1` (matches `.fvmrc`) and melos `7.4.0` (satisfies the `^7.1.0` constraint). Toolchain upgrades should land deliberately in their own PR.
