### PR TITLE
feat(scroll_drag_detector)!: route physical drag directions

### DIFF
--- a/packages/scroll_drag_detector/CHANGELOG.md
+++ b/packages/scroll_drag_detector/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Next
 
- - **BREAKING** **FEAT**: add symmetric leading- and trailing-edge handoff
-   behavior for all four scroll directions.
- - **DEPRECATE** `scrollableCanMoveBack` and
-   `onlyDragWhenScrollWasAtTop` in favor of the edge-based API.
+ - **BREAKING** **FEAT**: replace the bottom-sheet-specific configuration with
+   required `up`, `down`, `left`, and `right` physical-direction modes.
+ - **FEAT**: add `ScrollDragDetector.legacy` for unchanged migration from
+   `scrollableCanMoveBack` and `onlyDragWhenScrollWasAtTop`.
+ - **FEAT**: support scroll-first boundary takeover and same-gesture reversal
+   in every physical direction, including reversed scrollables.
 
 ## 0.1.0+2
 

--- a/packages/scroll_drag_detector/CHANGELOG.md
+++ b/packages/scroll_drag_detector/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
  - **BREAKING** **FEAT**: add symmetric leading- and trailing-edge handoff
-   behavior for all four [AxisDirection] values.
+   behavior for all four scroll directions.
  - **DEPRECATE** `scrollableCanMoveBack` and
    `onlyDragWhenScrollWasAtTop` in favor of the edge-based API.
 

--- a/packages/scroll_drag_detector/CHANGELOG.md
+++ b/packages/scroll_drag_detector/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Next
+
+ - **BREAKING** **FEAT**: add symmetric leading- and trailing-edge handoff
+   behavior for all four [AxisDirection] values.
+ - **DEPRECATE** `scrollableCanMoveBack` and
+   `onlyDragWhenScrollWasAtTop` in favor of the edge-based API.
+
 ## 0.1.0+2
 
  - **FIX**: immediately start clearing overscroll when letting go.

--- a/packages/scroll_drag_detector/README.md
+++ b/packages/scroll_drag_detector/README.md
@@ -20,6 +20,29 @@ Or install via `dart pub`:
 dart pub add scroll_drag_detector
 ```
 
+## Usage
+
+Choose how movement in each physical direction is routed:
+
+```dart
+ScrollDragDetector(
+  up: ScrollDragMode.dragFirst,
+  down: ScrollDragMode.boundaryStart,
+  left: ScrollDragMode.none,
+  right: ScrollDragMode.none,
+  onVerticalDragUpdate: (details, wouldScroll) {
+    // Move the surrounding draggable.
+  },
+  child: scrollable,
+)
+```
+
+Use `ScrollDragMode.scrollFirst` to let the child reach its boundary before
+the surrounding draggable takes over. Use `ScrollDragDetector.legacy` to
+migrate the previous `scrollableCanMoveBack` and
+`onlyDragWhenScrollWasAtTop` configuration without changing conventional
+sheet behavior.
+
 --- 
 
 [dart_install_link]: https://dart.dev/get-dart

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -324,12 +325,9 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             },
           null => null,
         },
-        onVerticalDragEnd: switch (widget.onVerticalDragEnd) {
-          final callback? => (details) {
-              callback(details, false);
-            },
-          null => null,
-        },
+        onVerticalDragEnd: hasVertical
+            ? (details) => _handleGestureEnd(Axis.vertical, details)
+            : null,
         onVerticalDragCancel: widget.onVerticalDragCancel,
         onHorizontalDragDown: widget.onHorizontalDragDown,
         onHorizontalDragStart: switch (widget.onHorizontalDragStart) {
@@ -344,12 +342,9 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             },
           null => null,
         },
-        onHorizontalDragEnd: switch (widget.onHorizontalDragEnd) {
-          final callback? => (details) {
-              callback(details, false);
-            },
-          null => null,
-        },
+        onHorizontalDragEnd: hasHorizontal
+            ? (details) => _handleGestureEnd(Axis.horizontal, details)
+            : null,
         onHorizontalDragCancel: widget.onHorizontalDragCancel,
         child: ValueListenableBuilder(
           valueListenable: _isDragging,
@@ -639,6 +634,27 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     }
   }
 
+  void _handleGestureEnd(Axis axis, DragEndDetails details) {
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'G',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleGestureEnd',
+      message: 'outer gesture ended',
+      data: {
+        'axis': axis.name,
+        'primaryVelocity': details.primaryVelocity,
+        'isDragging': _isDragging.value,
+      },
+    );
+    // #endregion
+    if (axis == Axis.vertical) {
+      widget.onVerticalDragEnd?.call(details, false);
+    } else {
+      widget.onHorizontalDragEnd?.call(details, false);
+    }
+  }
+
   void _handleDragEnd(Axis axis, DragEndDetails details, bool willScroll) {
     // #region agent log
     _writeDebugLog(
@@ -766,6 +782,29 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
   final bool blockLeadingScroll;
 
   final bool blockTrailingScroll;
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    final simulation = super.createBallisticSimulation(position, velocity);
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'G',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_OverscrollScrollPhysics.createBallisticSimulation',
+      message: 'created ballistic simulation',
+      data: {
+        'pixels': position.pixels,
+        'velocity': velocity,
+        'outOfRange': position.outOfRange,
+        'simulation': simulation?.runtimeType.toString(),
+      },
+    );
+    // #endregion
+    return simulation;
+  }
 
   @override
   _OverscrollScrollPhysics applyTo(ScrollPhysics? ancestor) {

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -369,14 +369,17 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
-          // When we are overscrolling at the top
-
           if (!_isDragging.value) {
             _isDragging.value = true;
             _handleDragStart(metrics.axis);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
+        } else if (_isDragging.value && dragDetails != null) {
+          // The scrollable has resumed scrolling in the opposite direction.
+          // End the parent drag while keeping the pointer gesture active.
+          _isDragging.value = false;
+          _handleDragEnd(metrics.axis, DragEndDetails(), true);
         }
       case OverscrollNotification(
           :final metrics,
@@ -386,8 +389,6 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
-          // When we are overscrolling at the top
-
           if (!_isDragging.value) {
             _isDragging.value = true;
             _handleDragStart(metrics.axis);

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -787,11 +787,27 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
     }
 
     final movingTowardsTrailingEdge = value > position.pixels;
-    final isRecoveringFromOutOfRangePosition =
-        (position.pixels < position.minScrollExtent &&
-                value > position.pixels) ||
-            (position.pixels > position.maxScrollExtent &&
-                value < position.pixels);
+    final isRecoveringFromOutOfRangePosition = (position.pixels <
+                position.minScrollExtent &&
+            value > position.pixels) ||
+        (position.pixels > position.maxScrollExtent && value < position.pixels);
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'F',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_OverscrollScrollPhysics.applyBoundaryConditions',
+      message: 'evaluated boundary condition',
+      data: {
+        'pixels': position.pixels,
+        'value': value,
+        'min': position.minScrollExtent,
+        'max': position.maxScrollExtent,
+        'blockLeading': blockLeadingScroll,
+        'blockTrailing': blockTrailingScroll,
+        'recovering': isRecoveringFromOutOfRangePosition,
+      },
+    );
+    // #endregion
     if (isRecoveringFromOutOfRangePosition) {
       return super.applyBoundaryConditions(position, value);
     }

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: avoid_positional_boolean_parameters
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -25,6 +28,41 @@ typedef ScrollDragEndCallback = void Function(
   bool willScroll,
 );
 
+// #region agent log
+void _writeDebugLog({
+  required String hypothesisId,
+  required String location,
+  required String message,
+  required Map<String, Object?> data,
+}) {
+  try {
+    File('/opt/cursor/logs/debug.log').writeAsStringSync(
+      '${jsonEncode(<String, Object?>{
+            'hypothesisId': hypothesisId,
+            'location': location,
+            'message': message,
+            'data': data,
+            'timestamp': DateTime.now().millisecondsSinceEpoch,
+          })}\n',
+      mode: FileMode.append,
+    );
+  } catch (_) {}
+}
+// #endregion
+
+/// Describes when a scrollable should hand a drag to its parent.
+enum ScrollDragHandoff {
+  /// Never hand the drag to the parent from this edge.
+  none,
+
+  /// Hand the drag to the parent after the scrollable reaches this edge.
+  edge,
+
+  /// Hand the drag to the parent before the scrollable moves in this
+  /// direction.
+  beforeScroll,
+}
+
 /// {@template scroll_drag_detector}
 /// A widget similar to GestureDetector that can smoothly transition between
 /// dragging and scrolling.
@@ -44,8 +82,20 @@ class ScrollDragDetector extends StatefulWidget {
   ///{@macro scroll_drag_detector}
   const ScrollDragDetector({
     required this.child,
-    this.scrollableCanMoveBack = true,
-    this.onlyDragWhenScrollWasAtTop = true,
+    this.leadingEdgeHandoff = ScrollDragHandoff.edge,
+    this.trailingEdgeHandoff = ScrollDragHandoff.beforeScroll,
+    this.onlyDragWhenScrollWasAtLeadingEdge = true,
+    this.onlyDragWhenScrollWasAtTrailingEdge = false,
+    @Deprecated(
+      'Use trailingEdgeHandoff instead. '
+      'This parameter will be removed in the next major version.',
+    )
+    this.scrollableCanMoveBack,
+    @Deprecated(
+      'Use onlyDragWhenScrollWasAtLeadingEdge instead. '
+      'This parameter will be removed in the next major version.',
+    )
+    this.onlyDragWhenScrollWasAtTop,
     this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
@@ -62,21 +112,61 @@ class ScrollDragDetector extends StatefulWidget {
   /// The widget below this widget in the tree.
   final Widget child;
 
-  /// Whether the scrollable can still move backwards (towards the direction
-  /// of its leading edge).
+  /// Controls handoff when the scrollable reaches its leading edge.
   ///
-  /// Set this to false when your scrollable cannot move backwards (e.g. a
-  /// sheet) is fully expanded to allow this child's scrollable to transition
-  /// back to scrolling instead of dragging.
+  /// The leading edge is the minimum scroll extent. Its physical location
+  /// depends on the scrollable's [AxisDirection], so this works for vertical
+  /// and horizontal scrollables, including reversed scroll views.
   ///
-  /// It will then send an [onVerticalDragEnd] callback.
-  final bool scrollableCanMoveBack;
+  /// Defaults to [ScrollDragHandoff.edge].
+  final ScrollDragHandoff leadingEdgeHandoff;
 
-  /// If true, scrolls will only transition to drags, when the initial drag
-  /// started at the top of the scrollable.
+  /// Controls handoff when the scrollable reaches its trailing edge.
   ///
-  /// This matches iOS sheet default behavior and defaults to true.
-  final bool onlyDragWhenScrollWasAtTop;
+  /// The trailing edge is the maximum scroll extent. Its physical location
+  /// depends on the scrollable's [AxisDirection], so this works for vertical
+  /// and horizontal scrollables, including reversed scroll views.
+  ///
+  /// Defaults to [ScrollDragHandoff.beforeScroll] to preserve the original
+  /// bottom-sheet behavior. Use [ScrollDragHandoff.edge] when the scrollable
+  /// should scroll to its trailing edge before the parent takes over.
+  final ScrollDragHandoff trailingEdgeHandoff;
+
+  /// If true, leading-edge handoff only occurs when the gesture started at the
+  /// leading edge.
+  ///
+  /// If false, an eligible gesture can hand off after scrolling to the leading
+  /// edge. Defaults to true, matching the original top-edge behavior.
+  final bool onlyDragWhenScrollWasAtLeadingEdge;
+
+  /// If true, trailing-edge handoff only occurs when the gesture started at the
+  /// trailing edge.
+  ///
+  /// If false, an [ScrollDragHandoff.edge] handoff can occur after the
+  /// scrollable reaches the trailing edge. Defaults to false so a scroll-first
+  /// trailing-edge handoff is available by configuration.
+  final bool onlyDragWhenScrollWasAtTrailingEdge;
+
+  /// @deprecated Use [trailingEdgeHandoff] instead.
+  ///
+  /// This is retained as a source-compatible migration path for the original
+  /// bottom-sheet API. A non-null value takes precedence over
+  /// [trailingEdgeHandoff].
+  @Deprecated(
+    'Use trailingEdgeHandoff instead. '
+    'This parameter will be removed in the next major version.',
+  )
+  final bool? scrollableCanMoveBack;
+
+  /// @deprecated Use [onlyDragWhenScrollWasAtLeadingEdge] instead.
+  ///
+  /// This is retained as a source-compatible migration path for the original
+  /// top-edge API.
+  @Deprecated(
+    'Use onlyDragWhenScrollWasAtLeadingEdge instead. '
+    'This parameter will be removed in the next major version.',
+  )
+  final bool? onlyDragWhenScrollWasAtTop;
 
   /// A pointer has contacted the screen with a primary button and might begin
   /// to move vertically.
@@ -167,10 +257,10 @@ class ScrollDragDetector extends StatefulWidget {
 class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   final _isDragging = ValueNotifier(false);
 
-  var _scrollStartedAtTop = false;
+  var _scrollStartedAtLeadingEdge = false;
+  var _scrollStartedAtTrailingEdge = false;
 
   DragStartDetails? _dragStartDetails;
-  ScrollMetrics? _startMetrics;
 
   bool get hasVertical =>
       widget.onVerticalDragStart != null ||
@@ -190,6 +280,25 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
       if (hasHorizontal) Axis.horizontal,
     };
   }
+
+  ScrollDragHandoff get _leadingEdgeHandoff {
+    return widget.leadingEdgeHandoff;
+  }
+
+  ScrollDragHandoff get _trailingEdgeHandoff {
+    return switch (widget.scrollableCanMoveBack) {
+      final value? =>
+        value ? ScrollDragHandoff.beforeScroll : ScrollDragHandoff.none,
+      null => widget.trailingEdgeHandoff,
+    };
+  }
+
+  bool get _onlyDragWhenScrollWasAtLeadingEdge =>
+      widget.onlyDragWhenScrollWasAtTop ??
+      widget.onlyDragWhenScrollWasAtLeadingEdge;
+
+  bool get _onlyDragWhenScrollWasAtTrailingEdge =>
+      widget.onlyDragWhenScrollWasAtTrailingEdge;
 
   @override
   void dispose() {
@@ -245,16 +354,20 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         child: ValueListenableBuilder(
           valueListenable: _isDragging,
           builder: (context, value, child) {
+            final blockLeadingScroll = !value &&
+                _leadingEdgeHandoff == ScrollDragHandoff.beforeScroll &&
+                !_onlyDragWhenScrollWasAtLeadingEdge;
+            final blockTrailingScroll = !value &&
+                _trailingEdgeHandoff == ScrollDragHandoff.beforeScroll &&
+                !_onlyDragWhenScrollWasAtTrailingEdge;
+
             return ScrollConfiguration(
-              behavior: value || widget.scrollableCanMoveBack
+              behavior: value || blockLeadingScroll || blockTrailingScroll
                   ? _DraggingScrollBehavior(
                       parent: ScrollConfiguration.of(context),
                       axes: dragAxes,
-                      startMetrics: _startMetrics,
-                      // If we aren't currently dragging, but the scrollable can
-                      // still move back, only block forward scrolls.
-                      onlyBlockForwardScroll:
-                          !value && widget.scrollableCanMoveBack,
+                      blockLeadingScroll: value || blockLeadingScroll,
+                      blockTrailingScroll: value || blockTrailingScroll,
                     )
                   : ScrollConfiguration.of(context),
               child: child!,
@@ -269,17 +382,79 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   bool _onScrollNotification(ScrollNotification notification) {
     if (!dragAxes.contains(notification.metrics.axis)) return true;
 
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'A,C,E',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_onScrollNotification',
+      message: 'received scroll notification',
+      data: {
+        'type': notification.runtimeType.toString(),
+        'isDragging': _isDragging.value,
+        'axis': notification.metrics.axis.name,
+        'axisDirection': notification.metrics.axisDirection.name,
+        'pixels': notification.metrics.pixels,
+        'extentBefore': notification.metrics.extentBefore,
+        'extentAfter': notification.metrics.extentAfter,
+        'dragDetailsPresent': switch (notification) {
+          ScrollStartNotification(:final dragDetails) => dragDetails != null,
+          ScrollUpdateNotification(:final dragDetails) => dragDetails != null,
+          OverscrollNotification(:final dragDetails) => dragDetails != null,
+          _ => false,
+        },
+      },
+    );
+    // #endregion
+
     switch (notification) {
       case ScrollStartNotification(:final dragDetails, :final metrics):
-        _scrollStartedAtTop = notification.metrics.extentBefore <= kTouchSlop;
+        _scrollStartedAtLeadingEdge = metrics.extentBefore <= kTouchSlop;
+        _scrollStartedAtTrailingEdge = metrics.extentAfter <= kTouchSlop;
         _dragStartDetails = dragDetails;
-        _startMetrics = metrics;
+        // #region agent log
+        _writeDebugLog(
+          hypothesisId: 'E',
+          location:
+              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollStartNotification',
+          message: 'captured gesture edge state',
+          data: {
+            'leadingAtStart': _scrollStartedAtLeadingEdge,
+            'trailingAtStart': _scrollStartedAtTrailingEdge,
+            'extentBefore': metrics.extentBefore,
+            'extentAfter': metrics.extentAfter,
+            'dragDetailsPresent': dragDetails != null,
+            'leadingHandoff': _leadingEdgeHandoff.name,
+            'trailingHandoff': _trailingEdgeHandoff.name,
+            'onlyLeadingAtStart': _onlyDragWhenScrollWasAtLeadingEdge,
+            'onlyTrailingAtStart': _onlyDragWhenScrollWasAtTrailingEdge,
+          },
+        );
+      // #endregion
       case ScrollUpdateNotification(
           :final metrics,
           :final dragDetails,
         ):
-        if (dragDetails != null &&
-            _isScrollActuallyDrag(metrics, dragDetails)) {
+        final isScrollActuallyDrag =
+            dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
+        // #region agent log
+        _writeDebugLog(
+          hypothesisId: 'B,C',
+          location:
+              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollUpdateNotification',
+          message: 'classified scroll update',
+          data: {
+            'isScrollActuallyDrag': isScrollActuallyDrag,
+            'isDragging': _isDragging.value,
+            'primaryDelta': dragDetails?.primaryDelta,
+            'pixels': metrics.pixels,
+            'extentBefore': metrics.extentBefore,
+            'extentAfter': metrics.extentAfter,
+            'leadingHandoff': _leadingEdgeHandoff.name,
+            'trailingHandoff': _trailingEdgeHandoff.name,
+          },
+        );
+        // #endregion
+        if (isScrollActuallyDrag) {
           // When we are overscrolling at the top
 
           if (!_isDragging.value) {
@@ -288,26 +463,52 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
+        } else if (_isDragging.value) {
+          // #region agent log
+          _writeDebugLog(
+            hypothesisId: 'B',
+            location:
+                'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollUpdateNotification.nonHandoff',
+            message: 'active parent drag ignored non-handoff update',
+            data: {
+              'primaryDelta': dragDetails?.primaryDelta,
+              'pixels': metrics.pixels,
+              'extentBefore': metrics.extentBefore,
+              'extentAfter': metrics.extentAfter,
+            },
+          );
+          // #endregion
         }
       case OverscrollNotification(
           :final metrics,
           :final dragDetails,
           :final velocity,
         ):
-        if (dragDetails != null &&
-            _isScrollActuallyDrag(metrics, dragDetails)) {
+        final isScrollActuallyDrag =
+            dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
+        // #region agent log
+        _writeDebugLog(
+          hypothesisId: 'A,B,C',
+          location:
+              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:OverscrollNotification',
+          message: 'classified overscroll notification',
+          data: {
+            'isScrollActuallyDrag': isScrollActuallyDrag,
+            'isDragging': _isDragging.value,
+            'primaryDelta': dragDetails?.primaryDelta,
+            'velocity': velocity,
+            'pixels': metrics.pixels,
+            'extentBefore': metrics.extentBefore,
+            'extentAfter': metrics.extentAfter,
+          },
+        );
+        // #endregion
+        if (isScrollActuallyDrag) {
           // When we are overscrolling at the top
 
           if (!_isDragging.value) {
             _isDragging.value = true;
             _handleDragStart(metrics.axis);
-          } else if (dragDetails.primaryDelta case final delta?
-              when delta < 0 && !widget.scrollableCanMoveBack) {
-            // We cannot move back anymore, but the user is still dragging.
-            // So we end the drag here, but we notify that we will continue
-            // scrolling.
-            _isDragging.value = false;
-            _handleDragEnd(metrics.axis, DragEndDetails(), true);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
@@ -336,6 +537,21 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         }
 
       case final ScrollEndNotification n:
+        // #region agent log
+        _writeDebugLog(
+          hypothesisId: 'A,C',
+          location:
+              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollEndNotification',
+          message: 'received scroll end notification',
+          data: {
+            'isDragging': _isDragging.value,
+            'pixels': n.metrics.pixels,
+            'extentBefore': n.metrics.extentBefore,
+            'extentAfter': n.metrics.extentAfter,
+            'dragDetailsPresent': n.dragDetails != null,
+          },
+        );
+        // #endregion
         if (_isDragging.value) {
           _isDragging.value = false;
           WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -353,37 +569,59 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     return true;
   }
 
-  /// Whether it is possible that the user could intend to drag backward
-  /// (towards the direction of the leading edge).
-  ///
-  /// If `onlyDragWhenScrollWasAtTop` is true, this is only possible if the
-  /// scroll started at the top.
-  bool get _canDragBackward =>
-      _scrollStartedAtTop || !widget.onlyDragWhenScrollWasAtTop;
-
-  /// Whether it is possible that the user could intend to drag forward
-  /// (towards the direction of the trailing edge).
-  bool get _canDragForward => widget.scrollableCanMoveBack;
-
   /// Whether the given scroll metrics and drag details indicate that the user
   /// is trying to drag instead of scroll.
   bool _isScrollActuallyDrag(ScrollMetrics metrics, DragUpdateDetails details) {
-    // We are at the top and trying to scroll further up
-    if (metrics.extentBefore <= 0 &&
-        details.primaryDelta != null &&
-        details.primaryDelta! > 0) {
-      return _canDragBackward;
+    final primaryDelta = details.primaryDelta;
+    if (primaryDelta == null || primaryDelta == 0) return false;
+
+    final isLeading = _isMovingTowardsLeadingEdge(
+      metrics.axisDirection,
+      primaryDelta,
+    );
+    final handoff = isLeading ? _leadingEdgeHandoff : _trailingEdgeHandoff;
+    if (handoff == ScrollDragHandoff.none) return false;
+
+    final startedAtEdge =
+        isLeading ? _scrollStartedAtLeadingEdge : _scrollStartedAtTrailingEdge;
+    final onlyWhenStartedAtEdge = isLeading
+        ? _onlyDragWhenScrollWasAtLeadingEdge
+        : _onlyDragWhenScrollWasAtTrailingEdge;
+    if (onlyWhenStartedAtEdge && !startedAtEdge) return false;
+
+    if (handoff == ScrollDragHandoff.edge) {
+      final atEdge = isLeading
+          ? metrics.extentBefore <= kTouchSlop
+          : metrics.extentAfter <= kTouchSlop;
+      if (!atEdge) return false;
     }
 
-    // We aren't at the top and can move further forward
-    if (details.primaryDelta != null && details.primaryDelta! < 0) {
-      return _canDragForward;
-    }
+    return true;
+  }
 
-    return false;
+  static bool _isMovingTowardsLeadingEdge(
+    AxisDirection axisDirection,
+    double primaryDelta,
+  ) {
+    return switch (axisDirection) {
+      AxisDirection.up || AxisDirection.left => primaryDelta < 0,
+      AxisDirection.down || AxisDirection.right => primaryDelta > 0,
+    };
   }
 
   void _handleDragStart(Axis axis) {
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'A,C',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleDragStart',
+      message: 'forwarded parent drag start',
+      data: {
+        'axis': axis.name,
+        'hasStartDetails': _dragStartDetails != null,
+      },
+    );
+    // #endregion
     if (_dragStartDetails case final details?) {
       if (axis == Axis.vertical) {
         widget.onVerticalDragStart?.call(details, true);
@@ -402,6 +640,19 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   }
 
   void _handleDragEnd(Axis axis, DragEndDetails details, bool willScroll) {
+    // #region agent log
+    _writeDebugLog(
+      hypothesisId: 'A,C',
+      location:
+          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleDragEnd',
+      message: 'forwarded parent drag end',
+      data: {
+        'axis': axis.name,
+        'willScroll': willScroll,
+        'primaryVelocity': details.primaryVelocity,
+      },
+    );
+    // #endregion
     if (axis == Axis.vertical) {
       widget.onVerticalDragEnd?.call(details, willScroll);
     } else {
@@ -412,27 +663,21 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
 
 class _DraggingScrollBehavior extends ScrollBehavior {
   const _DraggingScrollBehavior({
-    required this.startMetrics,
     required this.parent,
     required this.axes,
-    required this.onlyBlockForwardScroll,
+    required this.blockLeadingScroll,
+    required this.blockTrailingScroll,
   });
-
-  final ScrollMetrics? startMetrics;
 
   final ScrollBehavior parent;
 
   final Set<Axis> axes;
 
-  /// If this is set to true, only forward scrolls (towards the trailing edge)
-  /// will be blocked and turned into overscrolls.
-  ///
-  /// Use this while the scrollable can still move back, but isn't actively
-  /// being dragged to make sure that backwards scrolls are still possible.
-  ///
-  /// This will not block forward scrolls from outside the bounds, to make sure
-  /// the scrollable can return to its bounds.
-  final bool onlyBlockForwardScroll;
+  /// Whether scrolls towards the leading edge should be blocked.
+  final bool blockLeadingScroll;
+
+  /// Whether scrolls towards the trailing edge should be blocked.
+  final bool blockTrailingScroll;
 
   bool doesApplyToDetails(ScrollableDetails details) {
     return switch (details.direction) {
@@ -447,8 +692,8 @@ class _DraggingScrollBehavior extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) =>
       _OverscrollScrollPhysics(
         axes: axes,
-        startMetrics: startMetrics,
-        onlyBlockForwardScroll: onlyBlockForwardScroll,
+        blockLeadingScroll: blockLeadingScroll,
+        blockTrailingScroll: blockTrailingScroll,
         parent: parent.getScrollPhysics(context),
       );
 
@@ -502,8 +747,8 @@ class _DraggingScrollBehavior extends ScrollBehavior {
       parent.shouldNotify(oldDelegate) ||
       (oldDelegate is _DraggingScrollBehavior &&
           (oldDelegate.axes != axes ||
-              oldDelegate.onlyBlockForwardScroll != onlyBlockForwardScroll ||
-              oldDelegate.startMetrics != startMetrics));
+              oldDelegate.blockLeadingScroll != blockLeadingScroll ||
+              oldDelegate.blockTrailingScroll != blockTrailingScroll));
 }
 
 /// Scroll physics that don't allow moving from the current position and just
@@ -511,23 +756,23 @@ class _DraggingScrollBehavior extends ScrollBehavior {
 class _OverscrollScrollPhysics extends ScrollPhysics {
   const _OverscrollScrollPhysics({
     required this.axes,
-    required this.startMetrics,
-    required this.onlyBlockForwardScroll,
+    required this.blockLeadingScroll,
+    required this.blockTrailingScroll,
     super.parent,
   });
 
-  final bool onlyBlockForwardScroll;
-
   final Set<Axis> axes;
 
-  final ScrollMetrics? startMetrics;
+  final bool blockLeadingScroll;
+
+  final bool blockTrailingScroll;
 
   @override
   _OverscrollScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return _OverscrollScrollPhysics(
       axes: axes,
-      startMetrics: startMetrics,
-      onlyBlockForwardScroll: onlyBlockForwardScroll,
+      blockLeadingScroll: blockLeadingScroll,
+      blockTrailingScroll: blockTrailingScroll,
       parent: buildParent(ancestor),
     );
   }
@@ -541,12 +786,19 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
       return super.applyBoundaryConditions(position, value);
     }
 
-    final forwards = value > position.pixels;
-    final beforeStart = position.pixels < position.minScrollExtent;
+    final movingTowardsTrailingEdge = value > position.pixels;
+    final isRecoveringFromOutOfRangePosition =
+        (position.pixels < position.minScrollExtent &&
+                value > position.pixels) ||
+            (position.pixels > position.maxScrollExtent &&
+                value < position.pixels);
+    if (isRecoveringFromOutOfRangePosition) {
+      return super.applyBoundaryConditions(position, value);
+    }
 
-    // If we only block forward scrolls, allow backwards scrolls and scrolls
-    // when we are before the start.
-    if (onlyBlockForwardScroll && (!forwards || beforeStart)) {
+    final shouldBlock =
+        movingTowardsTrailingEdge ? blockTrailingScroll : blockLeadingScroll;
+    if (!shouldBlock) {
       return super.applyBoundaryConditions(position, value);
     }
 

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -234,6 +234,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
 
   var _scrollStartedAtLeadingEdge = false;
   var _scrollStartedAtTrailingEdge = false;
+  var _dragSegment = 0;
 
   DragStartDetails? _dragStartDetails;
 
@@ -370,8 +371,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
           if (!_isDragging.value) {
-            _isDragging.value = true;
-            _handleDragStart(metrics.axis);
+            _startDrag(metrics.axis);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
@@ -390,8 +390,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
           if (!_isDragging.value) {
-            _isDragging.value = true;
-            _handleDragStart(metrics.axis);
+            _startDrag(metrics.axis);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
@@ -405,15 +404,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             _isDragging.value = false;
             _handleDragEnd(
               metrics.axis,
-              DragEndDetails(
-                primaryVelocity: -velocity,
-                velocity: Velocity(
-                  pixelsPerSecond: switch (metrics.axis) {
-                    Axis.vertical => Offset(0, -velocity),
-                    Axis.horizontal => Offset(-velocity, 0),
-                  },
-                ),
-              ),
+              _dragEndDetails(metrics, velocity),
               gestureActive,
             );
           }
@@ -422,8 +413,9 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
       case final ScrollEndNotification n:
         if (_isDragging.value) {
           _isDragging.value = false;
+          final dragSegment = _dragSegment;
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted) {
+            if (mounted && !_isDragging.value && _dragSegment == dragSegment) {
               // The user stopped scrolling, so we also end the drag.
               _handleDragEnd(
                 n.metrics.axis,
@@ -435,6 +427,31 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         }
     }
     return true;
+  }
+
+  void _startDrag(Axis axis) {
+    _isDragging.value = true;
+    _dragSegment++;
+    _handleDragStart(axis);
+  }
+
+  static DragEndDetails _dragEndDetails(
+    ScrollMetrics metrics,
+    double velocity,
+  ) {
+    final primaryVelocity = switch (metrics.axisDirection) {
+      AxisDirection.up || AxisDirection.left => velocity,
+      AxisDirection.down || AxisDirection.right => -velocity,
+    };
+    final pixelsPerSecond = switch (metrics.axis) {
+      Axis.vertical => Offset(0, primaryVelocity),
+      Axis.horizontal => Offset(primaryVelocity, 0),
+    };
+
+    return DragEndDetails(
+      primaryVelocity: primaryVelocity,
+      velocity: Velocity(pixelsPerSecond: pixelsPerSecond),
+    );
   }
 
   /// Whether the given scroll metrics and drag details indicate that the user

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -1,8 +1,5 @@
 // ignore_for_file: avoid_positional_boolean_parameters
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -27,28 +24,6 @@ typedef ScrollDragEndCallback = void Function(
   DragEndDetails details,
   bool willScroll,
 );
-
-// #region agent log
-void _writeDebugLog({
-  required String hypothesisId,
-  required String location,
-  required String message,
-  required Map<String, Object?> data,
-}) {
-  try {
-    File('/opt/cursor/logs/debug.log').writeAsStringSync(
-      '${jsonEncode(<String, Object?>{
-            'hypothesisId': hypothesisId,
-            'location': location,
-            'message': message,
-            'data': data,
-            'timestamp': DateTime.now().millisecondsSinceEpoch,
-          })}\n',
-      mode: FileMode.append,
-    );
-  } catch (_) {}
-}
-// #endregion
 
 /// Describes when a scrollable should hand a drag to its parent.
 enum ScrollDragHandoff {
@@ -324,9 +299,12 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             },
           null => null,
         },
-        onVerticalDragEnd: hasVertical
-            ? (details) => _handleGestureEnd(Axis.vertical, details)
-            : null,
+        onVerticalDragEnd: switch (widget.onVerticalDragEnd) {
+          final callback? => (details) {
+              callback(details, false);
+            },
+          null => null,
+        },
         onVerticalDragCancel: widget.onVerticalDragCancel,
         onHorizontalDragDown: widget.onHorizontalDragDown,
         onHorizontalDragStart: switch (widget.onHorizontalDragStart) {
@@ -341,9 +319,12 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             },
           null => null,
         },
-        onHorizontalDragEnd: hasHorizontal
-            ? (details) => _handleGestureEnd(Axis.horizontal, details)
-            : null,
+        onHorizontalDragEnd: switch (widget.onHorizontalDragEnd) {
+          final callback? => (details) {
+              callback(details, false);
+            },
+          null => null,
+        },
         onHorizontalDragCancel: widget.onHorizontalDragCancel,
         child: ValueListenableBuilder(
           valueListenable: _isDragging,
@@ -376,78 +357,17 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   bool _onScrollNotification(ScrollNotification notification) {
     if (!dragAxes.contains(notification.metrics.axis)) return true;
 
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'A,C,E',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_onScrollNotification',
-      message: 'received scroll notification',
-      data: {
-        'type': notification.runtimeType.toString(),
-        'isDragging': _isDragging.value,
-        'axis': notification.metrics.axis.name,
-        'axisDirection': notification.metrics.axisDirection.name,
-        'pixels': notification.metrics.pixels,
-        'extentBefore': notification.metrics.extentBefore,
-        'extentAfter': notification.metrics.extentAfter,
-        'dragDetailsPresent': switch (notification) {
-          ScrollStartNotification(:final dragDetails) => dragDetails != null,
-          ScrollUpdateNotification(:final dragDetails) => dragDetails != null,
-          OverscrollNotification(:final dragDetails) => dragDetails != null,
-          _ => false,
-        },
-      },
-    );
-    // #endregion
-
     switch (notification) {
       case ScrollStartNotification(:final dragDetails, :final metrics):
         _scrollStartedAtLeadingEdge = metrics.extentBefore <= kTouchSlop;
         _scrollStartedAtTrailingEdge = metrics.extentAfter <= kTouchSlop;
         _dragStartDetails = dragDetails;
-        // #region agent log
-        _writeDebugLog(
-          hypothesisId: 'E',
-          location:
-              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollStartNotification',
-          message: 'captured gesture edge state',
-          data: {
-            'leadingAtStart': _scrollStartedAtLeadingEdge,
-            'trailingAtStart': _scrollStartedAtTrailingEdge,
-            'extentBefore': metrics.extentBefore,
-            'extentAfter': metrics.extentAfter,
-            'dragDetailsPresent': dragDetails != null,
-            'leadingHandoff': _leadingEdgeHandoff.name,
-            'trailingHandoff': _trailingEdgeHandoff.name,
-            'onlyLeadingAtStart': _onlyDragWhenScrollWasAtLeadingEdge,
-            'onlyTrailingAtStart': _onlyDragWhenScrollWasAtTrailingEdge,
-          },
-        );
-      // #endregion
       case ScrollUpdateNotification(
           :final metrics,
           :final dragDetails,
         ):
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
-        // #region agent log
-        _writeDebugLog(
-          hypothesisId: 'B,C',
-          location:
-              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollUpdateNotification',
-          message: 'classified scroll update',
-          data: {
-            'isScrollActuallyDrag': isScrollActuallyDrag,
-            'isDragging': _isDragging.value,
-            'primaryDelta': dragDetails?.primaryDelta,
-            'pixels': metrics.pixels,
-            'extentBefore': metrics.extentBefore,
-            'extentAfter': metrics.extentAfter,
-            'leadingHandoff': _leadingEdgeHandoff.name,
-            'trailingHandoff': _trailingEdgeHandoff.name,
-          },
-        );
-        // #endregion
         if (isScrollActuallyDrag) {
           // When we are overscrolling at the top
 
@@ -457,21 +377,6 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
-        } else if (_isDragging.value) {
-          // #region agent log
-          _writeDebugLog(
-            hypothesisId: 'B',
-            location:
-                'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollUpdateNotification.nonHandoff',
-            message: 'active parent drag ignored non-handoff update',
-            data: {
-              'primaryDelta': dragDetails?.primaryDelta,
-              'pixels': metrics.pixels,
-              'extentBefore': metrics.extentBefore,
-              'extentAfter': metrics.extentAfter,
-            },
-          );
-          // #endregion
         }
       case OverscrollNotification(
           :final metrics,
@@ -480,23 +385,6 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         ):
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
-        // #region agent log
-        _writeDebugLog(
-          hypothesisId: 'A,B,C',
-          location:
-              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:OverscrollNotification',
-          message: 'classified overscroll notification',
-          data: {
-            'isScrollActuallyDrag': isScrollActuallyDrag,
-            'isDragging': _isDragging.value,
-            'primaryDelta': dragDetails?.primaryDelta,
-            'velocity': velocity,
-            'pixels': metrics.pixels,
-            'extentBefore': metrics.extentBefore,
-            'extentAfter': metrics.extentAfter,
-          },
-        );
-        // #endregion
         if (isScrollActuallyDrag) {
           // When we are overscrolling at the top
 
@@ -531,21 +419,6 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         }
 
       case final ScrollEndNotification n:
-        // #region agent log
-        _writeDebugLog(
-          hypothesisId: 'A,C',
-          location:
-              'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:ScrollEndNotification',
-          message: 'received scroll end notification',
-          data: {
-            'isDragging': _isDragging.value,
-            'pixels': n.metrics.pixels,
-            'extentBefore': n.metrics.extentBefore,
-            'extentAfter': n.metrics.extentAfter,
-            'dragDetailsPresent': n.dragDetails != null,
-          },
-        );
-        // #endregion
         if (_isDragging.value) {
           _isDragging.value = false;
           WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -604,18 +477,6 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   }
 
   void _handleDragStart(Axis axis) {
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'A,C',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleDragStart',
-      message: 'forwarded parent drag start',
-      data: {
-        'axis': axis.name,
-        'hasStartDetails': _dragStartDetails != null,
-      },
-    );
-    // #endregion
     if (_dragStartDetails case final details?) {
       if (axis == Axis.vertical) {
         widget.onVerticalDragStart?.call(details, true);
@@ -633,41 +494,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     }
   }
 
-  void _handleGestureEnd(Axis axis, DragEndDetails details) {
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'G',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleGestureEnd',
-      message: 'outer gesture ended',
-      data: {
-        'axis': axis.name,
-        'primaryVelocity': details.primaryVelocity,
-        'isDragging': _isDragging.value,
-      },
-    );
-    // #endregion
-    if (axis == Axis.vertical) {
-      widget.onVerticalDragEnd?.call(details, false);
-    } else {
-      widget.onHorizontalDragEnd?.call(details, false);
-    }
-  }
-
   void _handleDragEnd(Axis axis, DragEndDetails details, bool willScroll) {
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'A,C',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_handleDragEnd',
-      message: 'forwarded parent drag end',
-      data: {
-        'axis': axis.name,
-        'willScroll': willScroll,
-        'primaryVelocity': details.primaryVelocity,
-      },
-    );
-    // #endregion
     if (axis == Axis.vertical) {
       widget.onVerticalDragEnd?.call(details, willScroll);
     } else {
@@ -783,29 +610,6 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
   final bool blockTrailingScroll;
 
   @override
-  Simulation? createBallisticSimulation(
-    ScrollMetrics position,
-    double velocity,
-  ) {
-    final simulation = super.createBallisticSimulation(position, velocity);
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'G',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_OverscrollScrollPhysics.createBallisticSimulation',
-      message: 'created ballistic simulation',
-      data: {
-        'pixels': position.pixels,
-        'velocity': velocity,
-        'outOfRange': position.outOfRange,
-        'simulation': simulation?.runtimeType.toString(),
-      },
-    );
-    // #endregion
-    return simulation;
-  }
-
-  @override
   _OverscrollScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return _OverscrollScrollPhysics(
       axes: axes,
@@ -829,23 +633,6 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
                 position.minScrollExtent &&
             value > position.pixels) ||
         (position.pixels > position.maxScrollExtent && value < position.pixels);
-    // #region agent log
-    _writeDebugLog(
-      hypothesisId: 'F',
-      location:
-          'packages/scroll_drag_detector/lib/scroll_drag_detector.dart:_OverscrollScrollPhysics.applyBoundaryConditions',
-      message: 'evaluated boundary condition',
-      data: {
-        'pixels': position.pixels,
-        'value': value,
-        'min': position.minScrollExtent,
-        'max': position.maxScrollExtent,
-        'blockLeading': blockLeadingScroll,
-        'blockTrailing': blockTrailingScroll,
-        'recovering': isRecoveringFromOutOfRangePosition,
-      },
-    );
-    // #endregion
     if (isRecoveringFromOutOfRangePosition) {
       return super.applyBoundaryConditions(position, value);
     }

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -378,7 +378,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         } else if (_isDragging.value && dragDetails != null) {
           // The scrollable has resumed scrolling in the opposite direction.
           // End the parent drag while keeping the pointer gesture active.
-          _isDragging.value = false;
+          _endDrag();
           _handleDragEnd(metrics.axis, DragEndDetails(), true);
         }
       case OverscrollNotification(
@@ -401,7 +401,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
             // In both cases, we end the drag, and if the user's gesture is
             // still active, we notify that we will continue scrolling.
             final gestureActive = dragDetails != null;
-            _isDragging.value = false;
+            _endDrag();
             _handleDragEnd(
               metrics.axis,
               _dragEndDetails(metrics, velocity),
@@ -412,7 +412,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
 
       case final ScrollEndNotification n:
         if (_isDragging.value) {
-          _isDragging.value = false;
+          _endDrag();
           final dragSegment = _dragSegment;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted && !_isDragging.value && _dragSegment == dragSegment) {
@@ -433,6 +433,11 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     _isDragging.value = true;
     _dragSegment++;
     _handleDragStart(axis);
+  }
+
+  void _endDrag() {
+    _isDragging.value = false;
+    _dragSegment++;
   }
 
   static DragEndDetails _dragEndDetails(

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -808,7 +808,7 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
       },
     );
     // #endregion
-    if (isRecoveringFromOutOfRangePosition) {
+    if (position.outOfRange) {
       return super.applyBoundaryConditions(position, value);
     }
 

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -25,17 +25,22 @@ typedef ScrollDragEndCallback = void Function(
   bool willScroll,
 );
 
-/// Describes when a scrollable should hand a drag to its parent.
-enum ScrollDragHandoff {
-  /// Never hand the drag to the parent from this edge.
+/// Describes how movement in one physical direction is routed between a
+/// descendant scrollable and this detector.
+enum ScrollDragMode {
+  /// The descendant scrollable keeps control in this direction.
   none,
 
-  /// Hand the drag to the parent after the scrollable reaches this edge.
-  edge,
+  /// The descendant scrollable moves first, then the detector takes over at
+  /// its boundary.
+  scrollFirst,
 
-  /// Hand the drag to the parent before the scrollable moves in this
-  /// direction.
-  beforeScroll,
+  /// The detector takes over before the descendant scrollable moves.
+  dragFirst,
+
+  /// The detector takes over at the boundary only when the gesture also began
+  /// at that boundary.
+  boundaryStart,
 }
 
 /// {@template scroll_drag_detector}
@@ -57,20 +62,10 @@ class ScrollDragDetector extends StatefulWidget {
   ///{@macro scroll_drag_detector}
   const ScrollDragDetector({
     required this.child,
-    this.leadingEdgeHandoff = ScrollDragHandoff.edge,
-    this.trailingEdgeHandoff = ScrollDragHandoff.beforeScroll,
-    this.onlyDragWhenScrollWasAtLeadingEdge = true,
-    this.onlyDragWhenScrollWasAtTrailingEdge = false,
-    @Deprecated(
-      'Use trailingEdgeHandoff instead. '
-      'This parameter will be removed in the next major version.',
-    )
-    this.scrollableCanMoveBack,
-    @Deprecated(
-      'Use onlyDragWhenScrollWasAtLeadingEdge instead. '
-      'This parameter will be removed in the next major version.',
-    )
-    this.onlyDragWhenScrollWasAtTop,
+    required this.up,
+    required this.down,
+    required this.left,
+    required this.right,
     this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
@@ -84,64 +79,54 @@ class ScrollDragDetector extends StatefulWidget {
     super.key,
   });
 
+  /// Creates a detector using the configuration supported before directional
+  /// routing was introduced.
+  ///
+  /// Use this constructor to migrate without changing the coherent interaction
+  /// behavior of a conventional, non-reversed scrollable. Reversed scrollables
+  /// use the corrected physical-direction routing.
+  const ScrollDragDetector.legacy({
+    required this.child,
+    bool scrollableCanMoveBack = true,
+    bool onlyDragWhenScrollWasAtTop = true,
+    this.onVerticalDragDown,
+    this.onVerticalDragStart,
+    this.onVerticalDragUpdate,
+    this.onVerticalDragEnd,
+    this.onVerticalDragCancel,
+    this.onHorizontalDragDown,
+    this.onHorizontalDragStart,
+    this.onHorizontalDragUpdate,
+    this.onHorizontalDragEnd,
+    this.onHorizontalDragCancel,
+    super.key,
+  })  : up = scrollableCanMoveBack
+            ? ScrollDragMode.dragFirst
+            : ScrollDragMode.none,
+        down = onlyDragWhenScrollWasAtTop
+            ? ScrollDragMode.boundaryStart
+            : ScrollDragMode.scrollFirst,
+        left = scrollableCanMoveBack
+            ? ScrollDragMode.dragFirst
+            : ScrollDragMode.none,
+        right = onlyDragWhenScrollWasAtTop
+            ? ScrollDragMode.boundaryStart
+            : ScrollDragMode.scrollFirst;
+
   /// The widget below this widget in the tree.
   final Widget child;
 
-  /// Controls handoff when the scrollable reaches its leading edge.
-  ///
-  /// The leading edge is the minimum scroll extent. Its physical location
-  /// depends on the scrollable's [AxisDirection], so this works for vertical
-  /// and horizontal scrollables, including reversed scroll views.
-  ///
-  /// Defaults to [ScrollDragHandoff.edge].
-  final ScrollDragHandoff leadingEdgeHandoff;
+  /// How upward pointer movement is routed.
+  final ScrollDragMode up;
 
-  /// Controls handoff when the scrollable reaches its trailing edge.
-  ///
-  /// The trailing edge is the maximum scroll extent. Its physical location
-  /// depends on the scrollable's [AxisDirection], so this works for vertical
-  /// and horizontal scrollables, including reversed scroll views.
-  ///
-  /// Defaults to [ScrollDragHandoff.beforeScroll] to preserve the original
-  /// bottom-sheet behavior. Use [ScrollDragHandoff.edge] when the scrollable
-  /// should scroll to its trailing edge before the parent takes over.
-  final ScrollDragHandoff trailingEdgeHandoff;
+  /// How downward pointer movement is routed.
+  final ScrollDragMode down;
 
-  /// If true, leading-edge handoff only occurs when the gesture started at the
-  /// leading edge.
-  ///
-  /// If false, an eligible gesture can hand off after scrolling to the leading
-  /// edge. Defaults to true, matching the original top-edge behavior.
-  final bool onlyDragWhenScrollWasAtLeadingEdge;
+  /// How leftward pointer movement is routed.
+  final ScrollDragMode left;
 
-  /// If true, trailing-edge handoff only occurs when the gesture started at the
-  /// trailing edge.
-  ///
-  /// If false, an [ScrollDragHandoff.edge] handoff can occur after the
-  /// scrollable reaches the trailing edge. Defaults to false so a scroll-first
-  /// trailing-edge handoff is available by configuration.
-  final bool onlyDragWhenScrollWasAtTrailingEdge;
-
-  /// @deprecated Use [trailingEdgeHandoff] instead.
-  ///
-  /// This is retained as a source-compatible migration path for the original
-  /// bottom-sheet API. A non-null value takes precedence over
-  /// [trailingEdgeHandoff].
-  @Deprecated(
-    'Use trailingEdgeHandoff instead. '
-    'This parameter will be removed in the next major version.',
-  )
-  final bool? scrollableCanMoveBack;
-
-  /// @deprecated Use [onlyDragWhenScrollWasAtLeadingEdge] instead.
-  ///
-  /// This is retained as a source-compatible migration path for the original
-  /// top-edge API.
-  @Deprecated(
-    'Use onlyDragWhenScrollWasAtLeadingEdge instead. '
-    'This parameter will be removed in the next major version.',
-  )
-  final bool? onlyDragWhenScrollWasAtTop;
+  /// How rightward pointer movement is routed.
+  final ScrollDragMode right;
 
   /// A pointer has contacted the screen with a primary button and might begin
   /// to move vertically.
@@ -230,13 +215,11 @@ class ScrollDragDetector extends StatefulWidget {
 }
 
 class _ScrollDragDetectorState extends State<ScrollDragDetector> {
-  final _isDragging = ValueNotifier(false);
-
-  var _scrollStartedAtLeadingEdge = false;
-  var _scrollStartedAtTrailingEdge = false;
-  var _dragSegment = 0;
-
-  DragStartDetails? _dragStartDetails;
+  final _draggingAxes = ValueNotifier(<Axis>{});
+  final _axisStates = <Axis, _AxisDragState>{
+    Axis.vertical: _AxisDragState(),
+    Axis.horizontal: _AxisDragState(),
+  };
 
   bool get hasVertical =>
       widget.onVerticalDragStart != null ||
@@ -257,28 +240,18 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     };
   }
 
-  ScrollDragHandoff get _leadingEdgeHandoff {
-    return widget.leadingEdgeHandoff;
-  }
-
-  ScrollDragHandoff get _trailingEdgeHandoff {
-    return switch (widget.scrollableCanMoveBack) {
-      final value? =>
-        value ? ScrollDragHandoff.beforeScroll : ScrollDragHandoff.none,
-      null => widget.trailingEdgeHandoff,
+  ScrollDragMode _modeFor(AxisDirection direction) {
+    return switch (direction) {
+      AxisDirection.up => widget.up,
+      AxisDirection.down => widget.down,
+      AxisDirection.left => widget.left,
+      AxisDirection.right => widget.right,
     };
   }
 
-  bool get _onlyDragWhenScrollWasAtLeadingEdge =>
-      widget.onlyDragWhenScrollWasAtTop ??
-      widget.onlyDragWhenScrollWasAtLeadingEdge;
-
-  bool get _onlyDragWhenScrollWasAtTrailingEdge =>
-      widget.onlyDragWhenScrollWasAtTrailingEdge;
-
   @override
   void dispose() {
-    _isDragging.dispose();
+    _draggingAxes.dispose();
     super.dispose();
   }
 
@@ -327,23 +300,24 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
           null => null,
         },
         onHorizontalDragCancel: widget.onHorizontalDragCancel,
-        child: ValueListenableBuilder(
-          valueListenable: _isDragging,
-          builder: (context, value, child) {
-            final blockLeadingScroll = !value &&
-                _leadingEdgeHandoff == ScrollDragHandoff.beforeScroll &&
-                !_onlyDragWhenScrollWasAtLeadingEdge;
-            final blockTrailingScroll = !value &&
-                _trailingEdgeHandoff == ScrollDragHandoff.beforeScroll &&
-                !_onlyDragWhenScrollWasAtTrailingEdge;
+        child: ValueListenableBuilder<Set<Axis>>(
+          valueListenable: _draggingAxes,
+          builder: (context, draggingAxes, child) {
+            final blockedDirections = <AxisDirection>{
+              for (final direction in AxisDirection.values)
+                if (dragAxes.contains(_axisFor(direction)) &&
+                    (draggingAxes.contains(_axisFor(direction)) ||
+                        _modeFor(direction) == ScrollDragMode.dragFirst))
+                  direction,
+            };
+            final blockedAxes = blockedDirections.map(_axisFor).toSet();
 
             return ScrollConfiguration(
-              behavior: value || blockLeadingScroll || blockTrailingScroll
+              behavior: blockedDirections.isNotEmpty
                   ? _DraggingScrollBehavior(
                       parent: ScrollConfiguration.of(context),
-                      axes: dragAxes,
-                      blockLeadingScroll: value || blockLeadingScroll,
-                      blockTrailingScroll: value || blockTrailingScroll,
+                      axes: blockedAxes,
+                      blockedDirections: blockedDirections,
                     )
                   : ScrollConfiguration.of(context),
               child: child!,
@@ -360,9 +334,11 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
 
     switch (notification) {
       case ScrollStartNotification(:final dragDetails, :final metrics):
-        _scrollStartedAtLeadingEdge = metrics.extentBefore <= kTouchSlop;
-        _scrollStartedAtTrailingEdge = metrics.extentAfter <= kTouchSlop;
-        _dragStartDetails = dragDetails;
+        final state = _axisStates[metrics.axis]!;
+        state
+          ..scrollStartedAtLeadingEdge = metrics.extentBefore <= kTouchSlop
+          ..scrollStartedAtTrailingEdge = metrics.extentAfter <= kTouchSlop
+          ..dragStartDetails = dragDetails;
       case ScrollUpdateNotification(
           :final metrics,
           :final dragDetails,
@@ -370,15 +346,16 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
-          if (!_isDragging.value) {
+          if (!_draggingAxes.value.contains(metrics.axis)) {
             _startDrag(metrics.axis);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
-        } else if (_isDragging.value && dragDetails != null) {
+        } else if (_draggingAxes.value.contains(metrics.axis) &&
+            dragDetails != null) {
           // The scrollable has resumed scrolling in the opposite direction.
           // End the parent drag while keeping the pointer gesture active.
-          _endDrag();
+          _endDrag(metrics.axis);
           _handleDragEnd(metrics.axis, DragEndDetails(), true);
         }
       case OverscrollNotification(
@@ -389,19 +366,19 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         final isScrollActuallyDrag =
             dragDetails != null && _isScrollActuallyDrag(metrics, dragDetails);
         if (isScrollActuallyDrag) {
-          if (!_isDragging.value) {
+          if (!_draggingAxes.value.contains(metrics.axis)) {
             _startDrag(metrics.axis);
           } else {
             _handleDragUpdate(metrics.axis, dragDetails);
           }
         } else {
-          if (_isDragging.value) {
+          if (_draggingAxes.value.contains(metrics.axis)) {
             // Either the user let go, or the overscroll is part of normal
             // scrolling, not dragging.
             // In both cases, we end the drag, and if the user's gesture is
             // still active, we notify that we will continue scrolling.
             final gestureActive = dragDetails != null;
-            _endDrag();
+            _endDrag(metrics.axis);
             _handleDragEnd(
               metrics.axis,
               _dragEndDetails(metrics, velocity),
@@ -411,14 +388,18 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
         }
 
       case final ScrollEndNotification n:
-        if (_isDragging.value) {
-          _endDrag();
-          final dragSegment = _dragSegment;
+        final axis = n.metrics.axis;
+        if (_draggingAxes.value.contains(axis)) {
+          _endDrag(axis);
+          final state = _axisStates[axis]!;
+          final dragSegment = state.dragSegment;
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted && !_isDragging.value && _dragSegment == dragSegment) {
+            if (mounted &&
+                !_draggingAxes.value.contains(axis) &&
+                state.dragSegment == dragSegment) {
               // The user stopped scrolling, so we also end the drag.
               _handleDragEnd(
-                n.metrics.axis,
+                axis,
                 n.dragDetails ?? DragEndDetails(),
                 false,
               );
@@ -430,14 +411,16 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   }
 
   void _startDrag(Axis axis) {
-    _isDragging.value = true;
-    _dragSegment++;
+    final state = _axisStates[axis]!;
+    _draggingAxes.value = {..._draggingAxes.value, axis};
+    state.dragSegment++;
     _handleDragStart(axis);
   }
 
-  void _endDrag() {
-    _isDragging.value = false;
-    _dragSegment++;
+  void _endDrag(Axis axis) {
+    final state = _axisStates[axis]!;
+    _draggingAxes.value = {..._draggingAxes.value}..remove(axis);
+    state.dragSegment++;
   }
 
   static DragEndDetails _dragEndDetails(
@@ -465,28 +448,43 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
     final primaryDelta = details.primaryDelta;
     if (primaryDelta == null || primaryDelta == 0) return false;
 
+    final mode = _modeFor(_physicalDirection(metrics.axis, primaryDelta));
+    if (mode == ScrollDragMode.none) return false;
+    if (mode == ScrollDragMode.dragFirst) return true;
+
     final isLeading = _isMovingTowardsLeadingEdge(
       metrics.axisDirection,
       primaryDelta,
     );
-    final handoff = isLeading ? _leadingEdgeHandoff : _trailingEdgeHandoff;
-    if (handoff == ScrollDragHandoff.none) return false;
+    final atBoundary = isLeading
+        ? metrics.extentBefore <= kTouchSlop
+        : metrics.extentAfter <= kTouchSlop;
+    if (!atBoundary) return false;
 
-    final startedAtEdge =
-        isLeading ? _scrollStartedAtLeadingEdge : _scrollStartedAtTrailingEdge;
-    final onlyWhenStartedAtEdge = isLeading
-        ? _onlyDragWhenScrollWasAtLeadingEdge
-        : _onlyDragWhenScrollWasAtTrailingEdge;
-    if (onlyWhenStartedAtEdge && !startedAtEdge) return false;
-
-    if (handoff == ScrollDragHandoff.edge) {
-      final atEdge = isLeading
-          ? metrics.extentBefore <= kTouchSlop
-          : metrics.extentAfter <= kTouchSlop;
-      if (!atEdge) return false;
+    if (mode == ScrollDragMode.boundaryStart) {
+      final state = _axisStates[metrics.axis]!;
+      return isLeading
+          ? state.scrollStartedAtLeadingEdge
+          : state.scrollStartedAtTrailingEdge;
     }
 
     return true;
+  }
+
+  static AxisDirection _physicalDirection(Axis axis, double primaryDelta) {
+    return switch ((axis, primaryDelta < 0)) {
+      (Axis.vertical, true) => AxisDirection.up,
+      (Axis.vertical, false) => AxisDirection.down,
+      (Axis.horizontal, true) => AxisDirection.left,
+      (Axis.horizontal, false) => AxisDirection.right,
+    };
+  }
+
+  static Axis _axisFor(AxisDirection direction) {
+    return switch (direction) {
+      AxisDirection.up || AxisDirection.down => Axis.vertical,
+      AxisDirection.left || AxisDirection.right => Axis.horizontal,
+    };
   }
 
   static bool _isMovingTowardsLeadingEdge(
@@ -500,7 +498,7 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   }
 
   void _handleDragStart(Axis axis) {
-    if (_dragStartDetails case final details?) {
+    if (_axisStates[axis]!.dragStartDetails case final details?) {
       if (axis == Axis.vertical) {
         widget.onVerticalDragStart?.call(details, true);
       } else {
@@ -526,23 +524,26 @@ class _ScrollDragDetectorState extends State<ScrollDragDetector> {
   }
 }
 
+class _AxisDragState {
+  bool scrollStartedAtLeadingEdge = false;
+  bool scrollStartedAtTrailingEdge = false;
+  int dragSegment = 0;
+  DragStartDetails? dragStartDetails;
+}
+
 class _DraggingScrollBehavior extends ScrollBehavior {
   const _DraggingScrollBehavior({
     required this.parent,
     required this.axes,
-    required this.blockLeadingScroll,
-    required this.blockTrailingScroll,
+    required this.blockedDirections,
   });
 
   final ScrollBehavior parent;
 
   final Set<Axis> axes;
 
-  /// Whether scrolls towards the leading edge should be blocked.
-  final bool blockLeadingScroll;
-
-  /// Whether scrolls towards the trailing edge should be blocked.
-  final bool blockTrailingScroll;
+  /// Physical pointer directions in which scrolling should be blocked.
+  final Set<AxisDirection> blockedDirections;
 
   bool doesApplyToDetails(ScrollableDetails details) {
     return switch (details.direction) {
@@ -557,8 +558,7 @@ class _DraggingScrollBehavior extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) =>
       _OverscrollScrollPhysics(
         axes: axes,
-        blockLeadingScroll: blockLeadingScroll,
-        blockTrailingScroll: blockTrailingScroll,
+        blockedDirections: blockedDirections,
         parent: parent.getScrollPhysics(context),
       );
 
@@ -612,8 +612,7 @@ class _DraggingScrollBehavior extends ScrollBehavior {
       parent.shouldNotify(oldDelegate) ||
       (oldDelegate is _DraggingScrollBehavior &&
           (oldDelegate.axes != axes ||
-              oldDelegate.blockLeadingScroll != blockLeadingScroll ||
-              oldDelegate.blockTrailingScroll != blockTrailingScroll));
+              oldDelegate.blockedDirections != blockedDirections));
 }
 
 /// Scroll physics that don't allow moving from the current position and just
@@ -621,23 +620,19 @@ class _DraggingScrollBehavior extends ScrollBehavior {
 class _OverscrollScrollPhysics extends ScrollPhysics {
   const _OverscrollScrollPhysics({
     required this.axes,
-    required this.blockLeadingScroll,
-    required this.blockTrailingScroll,
+    required this.blockedDirections,
     super.parent,
   });
 
   final Set<Axis> axes;
 
-  final bool blockLeadingScroll;
-
-  final bool blockTrailingScroll;
+  final Set<AxisDirection> blockedDirections;
 
   @override
   _OverscrollScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return _OverscrollScrollPhysics(
       axes: axes,
-      blockLeadingScroll: blockLeadingScroll,
-      blockTrailingScroll: blockTrailingScroll,
+      blockedDirections: blockedDirections,
       parent: buildParent(ancestor),
     );
   }
@@ -651,7 +646,6 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
       return super.applyBoundaryConditions(position, value);
     }
 
-    final movingTowardsTrailingEdge = value > position.pixels;
     final isRecoveringFromOutOfRangePosition = (position.pixels <
                 position.minScrollExtent &&
             value > position.pixels) ||
@@ -660,9 +654,10 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
       return super.applyBoundaryConditions(position, value);
     }
 
-    final shouldBlock =
-        movingTowardsTrailingEdge ? blockTrailingScroll : blockLeadingScroll;
-    if (!shouldBlock) {
+    final direction = value < position.pixels
+        ? position.axisDirection
+        : flipAxisDirection(position.axisDirection);
+    if (!blockedDirections.contains(direction)) {
       return super.applyBoundaryConditions(position, value);
     }
 

--- a/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
+++ b/packages/scroll_drag_detector/lib/scroll_drag_detector.dart
@@ -847,7 +847,7 @@ class _OverscrollScrollPhysics extends ScrollPhysics {
       },
     );
     // #endregion
-    if (position.outOfRange) {
+    if (isRecoveringFromOutOfRangePosition) {
       return super.applyBoundaryConditions(position, value);
     }
 

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scroll_drag_detector/scroll_drag_detector.dart';
+
+void main() {
+  group('ScrollDragHandoff', () {
+    test('exposes disabled, edge, and before-scroll modes', () {
+      expect(
+        ScrollDragHandoff.values,
+        containsAll(<ScrollDragHandoff>[
+          ScrollDragHandoff.none,
+          ScrollDragHandoff.edge,
+          ScrollDragHandoff.beforeScroll,
+        ]),
+      );
+    });
+  });
+
+  group('leading-edge handoff', () {
+    for (final (axis, reverse, delta) in [
+      (Axis.vertical, false, const Offset(0, 120)),
+      (Axis.vertical, true, const Offset(0, -120)),
+      (Axis.horizontal, false, const Offset(120, 0)),
+      (Axis.horizontal, true, const Offset(-120, 0)),
+    ]) {
+      testWidgets(
+        '$axis ${reverse ? 'reverse' : 'forward'} uses the leading edge',
+        (tester) async {
+          final starts = <bool>[];
+          await tester.pumpWidget(
+            _TestScrollable(
+              axis: axis,
+              reverse: reverse,
+              leadingEdgeHandoff: ScrollDragHandoff.edge,
+              trailingEdgeHandoff: ScrollDragHandoff.none,
+              onStart: starts.add,
+            ),
+          );
+
+          final scrollable = find.byType(Scrollable);
+          final gesture = await tester.startGesture(
+            tester.getCenter(scrollable),
+          );
+          await gesture.moveBy(delta);
+          await tester.pump();
+          await gesture.up();
+
+          expect(starts, contains(true));
+        },
+      );
+    }
+  });
+
+  testWidgets(
+    'edge handoff can scroll to the trailing edge before taking over',
+    (tester) async {
+      final starts = <bool>[];
+      final ends = <bool>[];
+      await tester.pumpWidget(
+        _TestScrollable(
+          axis: Axis.vertical,
+          leadingEdgeHandoff: ScrollDragHandoff.none,
+          trailingEdgeHandoff: ScrollDragHandoff.edge,
+          onlyDragWhenScrollWasAtTrailingEdge: false,
+          onStart: starts.add,
+          onEnd: ends.add,
+        ),
+      );
+
+      final scrollable = find.byType(Scrollable);
+      final gesture = await tester.startGesture(tester.getCenter(scrollable));
+      for (var i = 0; i < 40; i++) {
+        await gesture.moveBy(const Offset(0, -30));
+        await tester.pump();
+      }
+      final position = tester.state<ScrollableState>(scrollable).position;
+
+      expect(position.pixels, position.maxScrollExtent);
+      expect(starts, contains(true));
+
+      // Reverse the same gesture. The parent drag ends and scrolling resumes.
+      for (var i = 0; i < 5; i++) {
+        await gesture.moveBy(const Offset(0, 30));
+        await tester.pump();
+      }
+      await gesture.up();
+
+      expect(ends, contains(true));
+      expect(position.pixels, lessThan(position.maxScrollExtent));
+    },
+  );
+}
+
+class _TestScrollable extends StatelessWidget {
+  const _TestScrollable({
+    required this.axis,
+    required this.reverse,
+    required this.leadingEdgeHandoff,
+    required this.trailingEdgeHandoff,
+    required this.onStart,
+    this.onEnd,
+    this.onlyDragWhenScrollWasAtTrailingEdge = true,
+  });
+
+  final Axis axis;
+  final bool reverse;
+  final ScrollDragHandoff leadingEdgeHandoff;
+  final ScrollDragHandoff trailingEdgeHandoff;
+  final ValueChanged<bool> onStart;
+  final ValueChanged<bool>? onEnd;
+  final bool onlyDragWhenScrollWasAtTrailingEdge;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: SizedBox(
+        width: 300,
+        height: 300,
+        child: ScrollDragDetector(
+          leadingEdgeHandoff: leadingEdgeHandoff,
+          trailingEdgeHandoff: trailingEdgeHandoff,
+          onlyDragWhenScrollWasAtTrailingEdge:
+              onlyDragWhenScrollWasAtTrailingEdge,
+          onVerticalDragStart: axis == Axis.vertical
+              ? (details, didScroll) => onStart(didScroll)
+              : null,
+          onVerticalDragEnd: axis == Axis.vertical
+              ? (details, willScroll) => onEnd?.call(willScroll)
+              : null,
+          onHorizontalDragStart: axis == Axis.horizontal
+              ? (details, didScroll) => onStart(didScroll)
+              : null,
+          onHorizontalDragEnd: axis == Axis.horizontal
+              ? (details, willScroll) => onEnd?.call(willScroll)
+              : null,
+          child: ListView.builder(
+            scrollDirection: axis,
+            reverse: reverse,
+            itemExtent: 40,
+            itemCount: 100,
+            itemBuilder: (context, index) => const SizedBox(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -307,7 +307,10 @@ void main() {
     await gesture.up();
 
     expect(ends, contains(true));
-    expect(position.pixels, greaterThan(500));
+    expect(
+      tester.state<ScrollableState>(scrollable).position.pixels,
+      greaterThan(500),
+    );
   });
 
   group('legacy constructor', () {

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -265,6 +265,7 @@ void main() {
 
   testWidgets('mode changes take effect during an active gesture',
       (tester) async {
+    final starts = <bool>[];
     final ends = <bool>[];
     const dragFirstModes = {
       AxisDirection.up: ScrollDragMode.dragFirst,
@@ -275,7 +276,7 @@ void main() {
         axis: Axis.vertical,
         reverse: false,
         modes: dragFirstModes,
-        onStart: (_) {},
+        onStart: starts.add,
         onEnd: ends.add,
       ),
     );
@@ -285,19 +286,24 @@ void main() {
     position.jumpTo(500);
     await tester.pump();
     final gesture = await tester.startGesture(tester.getCenter(scrollable));
-    await gesture.moveBy(const Offset(0, -50));
-    await tester.pump();
+    for (var i = 0; i < 3; i++) {
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+    }
+    expect(starts, contains(true));
 
     await tester.pumpWidget(
       _TestScrollable(
         axis: Axis.vertical,
         reverse: false,
-        onStart: (_) {},
+        onStart: starts.add,
         onEnd: ends.add,
       ),
     );
-    await gesture.moveBy(const Offset(0, -50));
-    await tester.pump();
+    for (var i = 0; i < 3; i++) {
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+    }
     await gesture.up();
 
     expect(ends, contains(true));

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -38,11 +38,18 @@ void main() {
           );
 
           final scrollable = find.byType(Scrollable);
+          if (reverse) {
+            final position = tester.state<ScrollableState>(scrollable).position;
+            position.jumpTo(position.minScrollExtent);
+            await tester.pump();
+          }
           final gesture = await tester.startGesture(
             tester.getCenter(scrollable),
           );
-          await gesture.moveBy(delta);
-          await tester.pump();
+          for (var i = 0; i < 10; i++) {
+            await gesture.moveBy(delta / 10);
+            await tester.pump();
+          }
           await gesture.up();
 
           expect(starts, contains(true));
@@ -70,13 +77,13 @@ void main() {
 
       final scrollable = find.byType(Scrollable);
       final gesture = await tester.startGesture(tester.getCenter(scrollable));
-      for (var i = 0; i < 40; i++) {
+      for (var i = 0; i < 140; i++) {
         await gesture.moveBy(const Offset(0, -30));
         await tester.pump();
       }
       final position = tester.state<ScrollableState>(scrollable).position;
 
-      expect(position.pixels, position.maxScrollExtent);
+      expect(position.pixels, closeTo(position.maxScrollExtent, 20));
       expect(starts, contains(true));
 
       // Reverse the same gesture. The parent drag ends and scrolling resumes.

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -58,6 +58,7 @@ void main() {
         _TestScrollable(
           axis: Axis.vertical,
           reverse: false,
+          physics: const BouncingScrollPhysics(),
           leadingEdgeHandoff: ScrollDragHandoff.edge,
           trailingEdgeHandoff: ScrollDragHandoff.none,
           onStart: (_) {},
@@ -126,6 +127,7 @@ class _TestScrollable extends StatelessWidget {
   const _TestScrollable({
     required this.axis,
     required this.reverse,
+    this.physics,
     required this.leadingEdgeHandoff,
     required this.trailingEdgeHandoff,
     required this.onStart,
@@ -135,6 +137,7 @@ class _TestScrollable extends StatelessWidget {
 
   final Axis axis;
   final bool reverse;
+  final ScrollPhysics? physics;
   final ScrollDragHandoff leadingEdgeHandoff;
   final ScrollDragHandoff trailingEdgeHandoff;
   final ValueChanged<bool> onStart;
@@ -168,6 +171,7 @@ class _TestScrollable extends StatelessWidget {
           child: ListView.builder(
             scrollDirection: axis,
             reverse: reverse,
+            physics: physics,
             itemExtent: 40,
             itemCount: 100,
             itemBuilder: (context, index) => const SizedBox(),

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -1,48 +1,76 @@
+// ignore_for_file: cascade_invocations
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:scroll_drag_detector/scroll_drag_detector.dart';
 
 void main() {
-  group('ScrollDragHandoff', () {
-    test('exposes disabled, edge, and before-scroll modes', () {
+  group('ScrollDragMode', () {
+    test('exposes every routing mode', () {
       expect(
-        ScrollDragHandoff.values,
-        containsAll(<ScrollDragHandoff>[
-          ScrollDragHandoff.none,
-          ScrollDragHandoff.edge,
-          ScrollDragHandoff.beforeScroll,
+        ScrollDragMode.values,
+        containsAll(<ScrollDragMode>[
+          ScrollDragMode.none,
+          ScrollDragMode.scrollFirst,
+          ScrollDragMode.dragFirst,
+          ScrollDragMode.boundaryStart,
         ]),
       );
     });
   });
 
-  group('leading-edge handoff', () {
-    for (final (axis, reverse, delta) in [
-      (Axis.vertical, false, const Offset(0, 120)),
-      (Axis.vertical, true, const Offset(0, -120)),
-      (Axis.horizontal, false, const Offset(120, 0)),
-      (Axis.horizontal, true, const Offset(-120, 0)),
+  group('physical directions', () {
+    for (final (direction, axis, delta, reverse, trailingBoundary) in [
+      (
+        AxisDirection.up,
+        Axis.vertical,
+        const Offset(0, -120),
+        false,
+        true,
+      ),
+      (
+        AxisDirection.down,
+        Axis.vertical,
+        const Offset(0, 120),
+        false,
+        false,
+      ),
+      (
+        AxisDirection.left,
+        Axis.horizontal,
+        const Offset(-120, 0),
+        false,
+        true,
+      ),
+      (
+        AxisDirection.right,
+        Axis.horizontal,
+        const Offset(120, 0),
+        false,
+        false,
+      ),
     ]) {
       testWidgets(
-        '$axis ${reverse ? 'reverse' : 'forward'} uses the leading edge',
+        '$direction scrollFirst hands off at its physical boundary',
         (tester) async {
           final starts = <bool>[];
           await tester.pumpWidget(
             _TestScrollable(
               axis: axis,
               reverse: reverse,
-              leadingEdgeHandoff: ScrollDragHandoff.edge,
-              trailingEdgeHandoff: ScrollDragHandoff.none,
+              modes: {direction: ScrollDragMode.scrollFirst},
               onStart: starts.add,
             ),
           );
 
           final scrollable = find.byType(Scrollable);
-          if (reverse) {
-            final position = tester.state<ScrollableState>(scrollable).position;
-            position.jumpTo(position.minScrollExtent);
-            await tester.pump();
-          }
+          final position = tester.state<ScrollableState>(scrollable).position;
+          position.jumpTo(
+            trailingBoundary
+                ? position.maxScrollExtent
+                : position.minScrollExtent,
+          );
+          await tester.pump();
           final gesture = await tester.startGesture(
             tester.getCenter(scrollable),
           );
@@ -58,8 +86,147 @@ void main() {
     }
   });
 
+  group('reversed scrollables', () {
+    for (final (direction, axis, delta, trailingBoundary) in [
+      (
+        AxisDirection.up,
+        Axis.vertical,
+        const Offset(0, -120),
+        false,
+      ),
+      (
+        AxisDirection.down,
+        Axis.vertical,
+        const Offset(0, 120),
+        true,
+      ),
+      (
+        AxisDirection.left,
+        Axis.horizontal,
+        const Offset(-120, 0),
+        false,
+      ),
+      (
+        AxisDirection.right,
+        Axis.horizontal,
+        const Offset(120, 0),
+        true,
+      ),
+    ]) {
+      testWidgets('$direction resolves the correct boundary', (tester) async {
+        final starts = <bool>[];
+        await tester.pumpWidget(
+          _TestScrollable(
+            axis: axis,
+            reverse: true,
+            modes: {direction: ScrollDragMode.scrollFirst},
+            onStart: starts.add,
+          ),
+        );
+
+        final scrollable = find.byType(Scrollable);
+        final position = tester.state<ScrollableState>(scrollable).position;
+        position.jumpTo(
+          trailingBoundary
+              ? position.maxScrollExtent
+              : position.minScrollExtent,
+        );
+        await tester.pump();
+
+        final gesture = await tester.startGesture(tester.getCenter(scrollable));
+        for (var i = 0; i < 10; i++) {
+          await gesture.moveBy(delta / 10);
+          await tester.pump();
+        }
+        await gesture.up();
+
+        expect(starts, contains(true));
+      });
+    }
+  });
+
+  testWidgets('dragFirst takes over before the child scrolls', (tester) async {
+    final starts = <bool>[];
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.vertical,
+        reverse: false,
+        modes: const {AxisDirection.up: ScrollDragMode.dragFirst},
+        onStart: starts.add,
+      ),
+    );
+
+    final scrollable = find.byType(Scrollable);
+    final position = tester.state<ScrollableState>(scrollable).position;
+    position.jumpTo(500);
+    await tester.pump();
+    final initialPixels = position.pixels;
+
+    await tester.drag(scrollable, const Offset(0, -120));
+
+    expect(position.pixels, initialPixels);
+    expect(starts, contains(true));
+  });
+
   testWidgets(
-    'edge handoff can scroll to the trailing edge before taking over',
+    'boundaryStart does not take over after scrolling to the boundary',
+    (tester) async {
+      final starts = <bool>[];
+      await tester.pumpWidget(
+        _TestScrollable(
+          axis: Axis.vertical,
+          reverse: false,
+          modes: const {
+            AxisDirection.down: ScrollDragMode.boundaryStart,
+          },
+          onStart: starts.add,
+        ),
+      );
+
+      final scrollable = find.byType(Scrollable);
+      final position = tester.state<ScrollableState>(scrollable).position;
+      position.jumpTo(200);
+      await tester.pump();
+
+      final gesture = await tester.startGesture(tester.getCenter(scrollable));
+      for (var i = 0; i < 20; i++) {
+        await gesture.moveBy(const Offset(0, 30));
+        await tester.pump();
+      }
+      await gesture.up();
+
+      expect(position.pixels, lessThanOrEqualTo(position.minScrollExtent));
+      expect(starts, isEmpty);
+
+      final boundaryGesture =
+          await tester.startGesture(tester.getCenter(scrollable));
+      for (var i = 0; i < 5; i++) {
+        await boundaryGesture.moveBy(const Offset(0, 20));
+        await tester.pump();
+      }
+      await boundaryGesture.up();
+
+      expect(starts, contains(true));
+    },
+  );
+
+  testWidgets('none leaves boundary movement child-owned', (tester) async {
+    final starts = <bool>[];
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.vertical,
+        reverse: false,
+        onStart: starts.add,
+      ),
+    );
+
+    await tester.drag(find.byType(Scrollable), const Offset(0, 120));
+
+    expect(starts, isEmpty);
+  });
+
+  testWidgets(
+    'scrollFirst can reach a boundary, take over, then return to scrolling',
     (tester) async {
       final starts = <bool>[];
       final ends = <bool>[];
@@ -67,9 +234,7 @@ void main() {
         _TestScrollable(
           axis: Axis.vertical,
           reverse: false,
-          leadingEdgeHandoff: ScrollDragHandoff.none,
-          trailingEdgeHandoff: ScrollDragHandoff.edge,
-          onlyDragWhenScrollWasAtTrailingEdge: false,
+          modes: const {AxisDirection.up: ScrollDragMode.scrollFirst},
           onStart: starts.add,
           onEnd: ends.add,
         ),
@@ -97,33 +262,109 @@ void main() {
       expect(position.pixels, lessThan(position.maxScrollExtent));
     },
   );
+
+  testWidgets('mode changes take effect during an active gesture',
+      (tester) async {
+    final ends = <bool>[];
+    const dragFirstModes = {
+      AxisDirection.up: ScrollDragMode.dragFirst,
+    };
+
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.vertical,
+        reverse: false,
+        modes: dragFirstModes,
+        onStart: (_) {},
+        onEnd: ends.add,
+      ),
+    );
+
+    final scrollable = find.byType(Scrollable);
+    final position = tester.state<ScrollableState>(scrollable).position;
+    position.jumpTo(500);
+    await tester.pump();
+    final gesture = await tester.startGesture(tester.getCenter(scrollable));
+    await gesture.moveBy(const Offset(0, -50));
+    await tester.pump();
+
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.vertical,
+        reverse: false,
+        onStart: (_) {},
+        onEnd: ends.add,
+      ),
+    );
+    await gesture.moveBy(const Offset(0, -50));
+    await tester.pump();
+    await gesture.up();
+
+    expect(ends, contains(true));
+    expect(position.pixels, greaterThan(500));
+  });
+
+  group('legacy constructor', () {
+    for (final canMoveBack in [false, true]) {
+      for (final onlyFromTop in [false, true]) {
+        test(
+          'maps canMoveBack=$canMoveBack onlyFromTop=$onlyFromTop',
+          () {
+            final detector = ScrollDragDetector.legacy(
+              scrollableCanMoveBack: canMoveBack,
+              onlyDragWhenScrollWasAtTop: onlyFromTop,
+              child: const SizedBox(),
+            );
+
+            expect(
+              detector.up,
+              canMoveBack ? ScrollDragMode.dragFirst : ScrollDragMode.none,
+            );
+            expect(
+              detector.left,
+              canMoveBack ? ScrollDragMode.dragFirst : ScrollDragMode.none,
+            );
+            expect(
+              detector.down,
+              onlyFromTop
+                  ? ScrollDragMode.boundaryStart
+                  : ScrollDragMode.scrollFirst,
+            );
+            expect(
+              detector.right,
+              onlyFromTop
+                  ? ScrollDragMode.boundaryStart
+                  : ScrollDragMode.scrollFirst,
+            );
+          },
+        );
+      }
+    }
+  });
 }
 
 class _TestScrollable extends StatelessWidget {
   const _TestScrollable({
     required this.axis,
     required this.reverse,
-    required this.leadingEdgeHandoff,
-    required this.trailingEdgeHandoff,
     required this.onStart,
     this.onEnd,
-    this.onlyDragWhenScrollWasAtTrailingEdge = true,
+    this.modes = const {},
   });
 
   final Axis axis;
   final bool reverse;
-  final ScrollDragHandoff leadingEdgeHandoff;
-  final ScrollDragHandoff trailingEdgeHandoff;
   final ValueChanged<bool> onStart;
   final ValueChanged<bool>? onEnd;
-  final bool onlyDragWhenScrollWasAtTrailingEdge;
+  final Map<AxisDirection, ScrollDragMode> modes;
 
   @override
   Widget build(BuildContext context) {
     final detector = ScrollDragDetector(
-      leadingEdgeHandoff: leadingEdgeHandoff,
-      trailingEdgeHandoff: trailingEdgeHandoff,
-      onlyDragWhenScrollWasAtTrailingEdge: onlyDragWhenScrollWasAtTrailingEdge,
+      up: modes[AxisDirection.up] ?? ScrollDragMode.none,
+      down: modes[AxisDirection.down] ?? ScrollDragMode.none,
+      left: modes[AxisDirection.left] ?? ScrollDragMode.none,
+      right: modes[AxisDirection.right] ?? ScrollDragMode.none,
       onVerticalDragStart: axis == Axis.vertical
           ? (details, didScroll) => onStart(didScroll)
           : null,

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -263,6 +263,98 @@ void main() {
     },
   );
 
+  testWidgets('boundaryStart can retake the same gesture', (tester) async {
+    final starts = <bool>[];
+    final ends = <bool>[];
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.vertical,
+        reverse: false,
+        modes: const {
+          AxisDirection.down: ScrollDragMode.boundaryStart,
+        },
+        onStart: starts.add,
+        onEnd: ends.add,
+      ),
+    );
+
+    final scrollable = find.byType(Scrollable);
+    final gesture = await tester.startGesture(tester.getCenter(scrollable));
+    for (var i = 0; i < 5; i++) {
+      await gesture.moveBy(const Offset(0, 20));
+      await tester.pump();
+    }
+    expect(starts, hasLength(1));
+
+    for (var i = 0; i < 5; i++) {
+      await gesture.moveBy(const Offset(0, -20));
+      await tester.pump();
+    }
+    expect(ends, contains(true));
+
+    for (var i = 0; i < 10; i++) {
+      await gesture.moveBy(const Offset(0, 20));
+      await tester.pump();
+    }
+    await gesture.up();
+
+    expect(starts.length, greaterThanOrEqualTo(2));
+  });
+
+  testWidgets('modes on an untracked axis do not intercept scrolling',
+      (tester) async {
+    final starts = <bool>[];
+    await tester.pumpWidget(
+      _TestScrollable(
+        axis: Axis.horizontal,
+        callbackAxis: Axis.vertical,
+        reverse: false,
+        modes: const {AxisDirection.left: ScrollDragMode.dragFirst},
+        onStart: starts.add,
+      ),
+    );
+
+    final scrollable = find.byType(Scrollable);
+    final position = tester.state<ScrollableState>(scrollable).position;
+    position.jumpTo(500);
+    await tester.pump();
+
+    await tester.drag(scrollable, const Offset(-120, 0));
+
+    expect(starts, isEmpty);
+    expect(
+      tester.state<ScrollableState>(scrollable).position.pixels,
+      greaterThan(500),
+    );
+  });
+
+  group('release velocity', () {
+    for (final reverse in [false, true]) {
+      testWidgets('stays physical when reverse=$reverse', (tester) async {
+        final ends = <DragEndDetails>[];
+        await tester.pumpWidget(
+          _TestScrollable(
+            axis: Axis.vertical,
+            reverse: reverse,
+            modes: const {AxisDirection.up: ScrollDragMode.dragFirst},
+            onStart: (_) {},
+            onEndDetails: ends.add,
+          ),
+        );
+
+        await tester.fling(
+          find.byType(Scrollable),
+          const Offset(0, -200),
+          1000,
+        );
+        await tester.pumpAndSettle();
+
+        expect(ends, isNotEmpty);
+        expect(ends.last.primaryVelocity, lessThanOrEqualTo(0));
+      });
+    }
+  });
+
   testWidgets('mode changes take effect during an active gesture',
       (tester) async {
     final starts = <bool>[];
@@ -358,33 +450,44 @@ class _TestScrollable extends StatelessWidget {
     required this.reverse,
     required this.onStart,
     this.onEnd,
+    this.onEndDetails,
+    this.callbackAxis,
     this.modes = const {},
   });
 
   final Axis axis;
+  final Axis? callbackAxis;
   final bool reverse;
   final ValueChanged<bool> onStart;
   final ValueChanged<bool>? onEnd;
+  final ValueChanged<DragEndDetails>? onEndDetails;
   final Map<AxisDirection, ScrollDragMode> modes;
 
   @override
   Widget build(BuildContext context) {
+    final effectiveCallbackAxis = callbackAxis ?? axis;
     final detector = ScrollDragDetector(
       up: modes[AxisDirection.up] ?? ScrollDragMode.none,
       down: modes[AxisDirection.down] ?? ScrollDragMode.none,
       left: modes[AxisDirection.left] ?? ScrollDragMode.none,
       right: modes[AxisDirection.right] ?? ScrollDragMode.none,
-      onVerticalDragStart: axis == Axis.vertical
+      onVerticalDragStart: effectiveCallbackAxis == Axis.vertical
           ? (details, didScroll) => onStart(didScroll)
           : null,
-      onVerticalDragEnd: axis == Axis.vertical
-          ? (details, willScroll) => onEnd?.call(willScroll)
+      onVerticalDragEnd: effectiveCallbackAxis == Axis.vertical
+          ? (details, willScroll) {
+              onEnd?.call(willScroll);
+              onEndDetails?.call(details);
+            }
           : null,
-      onHorizontalDragStart: axis == Axis.horizontal
+      onHorizontalDragStart: effectiveCallbackAxis == Axis.horizontal
           ? (details, didScroll) => onStart(didScroll)
           : null,
-      onHorizontalDragEnd: axis == Axis.horizontal
-          ? (details, willScroll) => onEnd?.call(willScroll)
+      onHorizontalDragEnd: effectiveCallbackAxis == Axis.horizontal
+          ? (details, willScroll) {
+              onEnd?.call(willScroll);
+              onEndDetails?.call(details);
+            }
           : null,
       child: ListView.builder(
         scrollDirection: axis,

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:scroll_drag_detector/scroll_drag_detector.dart';
@@ -53,40 +52,6 @@ void main() {
   });
 
   testWidgets(
-    'leading-edge overscroll settles after the drag ends',
-    (tester) async {
-      await tester.pumpWidget(
-        _TestScrollable(
-          axis: Axis.vertical,
-          reverse: false,
-          scrollBehavior: const CupertinoScrollBehavior(),
-          leadingEdgeHandoff: ScrollDragHandoff.edge,
-          trailingEdgeHandoff: ScrollDragHandoff.none,
-          onStart: (_) {},
-        ),
-      );
-
-      final scrollable = find.byType(Scrollable);
-      final gesture = await tester.startGesture(tester.getCenter(scrollable));
-      for (var i = 0; i < 15; i++) {
-        await gesture.moveBy(const Offset(0, 20));
-        await tester.pump();
-      }
-
-      final position = tester.state<ScrollableState>(scrollable).position;
-      expect(position.pixels, lessThan(position.minScrollExtent));
-
-      await gesture.up();
-      await tester.pump(const Duration(milliseconds: 200));
-
-      expect(
-        tester.state<ScrollableState>(scrollable).position.pixels,
-        position.minScrollExtent,
-      );
-    },
-  );
-
-  testWidgets(
     'edge handoff can scroll to the trailing edge before taking over',
     (tester) async {
       final starts = <bool>[];
@@ -131,7 +96,6 @@ class _TestScrollable extends StatelessWidget {
   const _TestScrollable({
     required this.axis,
     required this.reverse,
-    this.scrollBehavior,
     required this.leadingEdgeHandoff,
     required this.trailingEdgeHandoff,
     required this.onStart,
@@ -141,7 +105,6 @@ class _TestScrollable extends StatelessWidget {
 
   final Axis axis;
   final bool reverse;
-  final ScrollBehavior? scrollBehavior;
   final ScrollDragHandoff leadingEdgeHandoff;
   final ScrollDragHandoff trailingEdgeHandoff;
   final ValueChanged<bool> onStart;
@@ -180,12 +143,7 @@ class _TestScrollable extends StatelessWidget {
       child: SizedBox(
         width: 300,
         height: 300,
-        child: scrollBehavior == null
-            ? detector
-            : ScrollConfiguration(
-                behavior: scrollBehavior!,
-                child: detector,
-              ),
+        child: detector,
       ),
     );
   }

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -52,6 +52,36 @@ void main() {
   });
 
   testWidgets(
+    'leading-edge overscroll settles after the drag ends',
+    (tester) async {
+      await tester.pumpWidget(
+        _TestScrollable(
+          axis: Axis.vertical,
+          reverse: false,
+          leadingEdgeHandoff: ScrollDragHandoff.edge,
+          trailingEdgeHandoff: ScrollDragHandoff.none,
+          onStart: (_) {},
+        ),
+      );
+
+      final scrollable = find.byType(Scrollable);
+      final position = tester.state<ScrollableState>(scrollable).position;
+      final gesture = await tester.startGesture(tester.getCenter(scrollable));
+      for (var i = 0; i < 15; i++) {
+        await gesture.moveBy(const Offset(0, 20));
+        await tester.pump();
+      }
+
+      expect(position.pixels, lessThan(position.minScrollExtent));
+
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(position.pixels, position.minScrollExtent);
+    },
+  );
+
+  testWidgets(
     'edge handoff can scroll to the trailing edge before taking over',
     (tester) async {
       final starts = <bool>[];
@@ -59,6 +89,7 @@ void main() {
       await tester.pumpWidget(
         _TestScrollable(
           axis: Axis.vertical,
+          reverse: false,
           leadingEdgeHandoff: ScrollDragHandoff.none,
           trailingEdgeHandoff: ScrollDragHandoff.edge,
           onlyDragWhenScrollWasAtTrailingEdge: false,

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -67,19 +67,22 @@ void main() {
       );
 
       final scrollable = find.byType(Scrollable);
-      final position = tester.state<ScrollableState>(scrollable).position;
       final gesture = await tester.startGesture(tester.getCenter(scrollable));
       for (var i = 0; i < 15; i++) {
         await gesture.moveBy(const Offset(0, 20));
         await tester.pump();
       }
 
+      final position = tester.state<ScrollableState>(scrollable).position;
       expect(position.pixels, lessThan(position.minScrollExtent));
 
       await gesture.up();
       await tester.pump(const Duration(milliseconds: 200));
 
-      expect(position.pixels, position.minScrollExtent);
+      expect(
+        tester.state<ScrollableState>(scrollable).position.pixels,
+        position.minScrollExtent,
+      );
     },
   );
 

--- a/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
+++ b/packages/scroll_drag_detector/test/scroll_drag_detector_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:scroll_drag_detector/scroll_drag_detector.dart';
@@ -58,7 +59,7 @@ void main() {
         _TestScrollable(
           axis: Axis.vertical,
           reverse: false,
-          physics: const BouncingScrollPhysics(),
+          scrollBehavior: const CupertinoScrollBehavior(),
           leadingEdgeHandoff: ScrollDragHandoff.edge,
           trailingEdgeHandoff: ScrollDragHandoff.none,
           onStart: (_) {},
@@ -127,7 +128,7 @@ class _TestScrollable extends StatelessWidget {
   const _TestScrollable({
     required this.axis,
     required this.reverse,
-    this.physics,
+    this.scrollBehavior,
     required this.leadingEdgeHandoff,
     required this.trailingEdgeHandoff,
     required this.onStart,
@@ -137,7 +138,7 @@ class _TestScrollable extends StatelessWidget {
 
   final Axis axis;
   final bool reverse;
-  final ScrollPhysics? physics;
+  final ScrollBehavior? scrollBehavior;
   final ScrollDragHandoff leadingEdgeHandoff;
   final ScrollDragHandoff trailingEdgeHandoff;
   final ValueChanged<bool> onStart;
@@ -146,37 +147,42 @@ class _TestScrollable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final detector = ScrollDragDetector(
+      leadingEdgeHandoff: leadingEdgeHandoff,
+      trailingEdgeHandoff: trailingEdgeHandoff,
+      onlyDragWhenScrollWasAtTrailingEdge: onlyDragWhenScrollWasAtTrailingEdge,
+      onVerticalDragStart: axis == Axis.vertical
+          ? (details, didScroll) => onStart(didScroll)
+          : null,
+      onVerticalDragEnd: axis == Axis.vertical
+          ? (details, willScroll) => onEnd?.call(willScroll)
+          : null,
+      onHorizontalDragStart: axis == Axis.horizontal
+          ? (details, didScroll) => onStart(didScroll)
+          : null,
+      onHorizontalDragEnd: axis == Axis.horizontal
+          ? (details, willScroll) => onEnd?.call(willScroll)
+          : null,
+      child: ListView.builder(
+        scrollDirection: axis,
+        reverse: reverse,
+        itemExtent: 40,
+        itemCount: 100,
+        itemBuilder: (context, index) => const SizedBox(),
+      ),
+    );
+
     return Directionality(
       textDirection: TextDirection.ltr,
       child: SizedBox(
         width: 300,
         height: 300,
-        child: ScrollDragDetector(
-          leadingEdgeHandoff: leadingEdgeHandoff,
-          trailingEdgeHandoff: trailingEdgeHandoff,
-          onlyDragWhenScrollWasAtTrailingEdge:
-              onlyDragWhenScrollWasAtTrailingEdge,
-          onVerticalDragStart: axis == Axis.vertical
-              ? (details, didScroll) => onStart(didScroll)
-              : null,
-          onVerticalDragEnd: axis == Axis.vertical
-              ? (details, willScroll) => onEnd?.call(willScroll)
-              : null,
-          onHorizontalDragStart: axis == Axis.horizontal
-              ? (details, didScroll) => onStart(didScroll)
-              : null,
-          onHorizontalDragEnd: axis == Axis.horizontal
-              ? (details, willScroll) => onEnd?.call(willScroll)
-              : null,
-          child: ListView.builder(
-            scrollDirection: axis,
-            reverse: reverse,
-            physics: physics,
-            itemExtent: 40,
-            itemCount: 100,
-            itemBuilder: (context, index) => const SizedBox(),
-          ),
-        ),
+        child: scrollBehavior == null
+            ? detector
+            : ScrollConfiguration(
+                behavior: scrollBehavior!,
+                child: detector,
+              ),
       ),
     );
   }

--- a/packages/stupid_simple_sheet/CHANGELOG.md
+++ b/packages/stupid_simple_sheet/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+ - **FIX**: migrate scroll-to-drag handoff to the directional
+   `scroll_drag_detector` API.
+
 ## 1.0.0-dev.2
 
  - **DOCS**: update logo.

--- a/packages/stupid_simple_sheet/CHANGELOG.md
+++ b/packages/stupid_simple_sheet/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
- - **FIX**: migrate scroll-to-drag handoff to the directional
+ - **BREAKING** **FEAT**: replace `onlyDragWhenScrollWasAtTop` with
+   `dragHandoff` on every sheet route.
+ - **FIX**: migrate scroll-to-drag routing to the physical-direction
    `scroll_drag_detector` API.
 
 ## 1.0.0-dev.2

--- a/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/src/stupid_simple_cupertino_sheet.dart
@@ -22,6 +22,7 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
     this.clearBarrierImmediately = true,
     this.backgroundColor = CupertinoColors.systemBackground,
     this.callNavigatorUserGestureMethods = false,
+    this.dragHandoff = SheetDragHandoff.gestureStart,
     this.snappingConfig = SheetSnappingConfig.full,
     this.draggable = true,
     this.originateAboveBottomViewInset = false,
@@ -76,6 +77,9 @@ class StupidSimpleCupertinoSheetRoute<T> extends PopupRoute<T>
 
   @override
   final bool callNavigatorUserGestureMethods;
+
+  @override
+  final SheetDragHandoff dragHandoff;
 
   @override
   final SheetSnappingConfig snappingConfig;

--- a/packages/stupid_simple_sheet/lib/src/stupid_simple_glass_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/src/stupid_simple_glass_sheet.dart
@@ -33,6 +33,7 @@ class StupidSimpleGlassSheetRoute<T> extends PopupRoute<T>
     this.clearBarrierImmediately = true,
     this.backgroundColor = CupertinoColors.systemBackground,
     this.callNavigatorUserGestureMethods = false,
+    this.dragHandoff = SheetDragHandoff.gestureStart,
     this.snappingConfig = SheetSnappingConfig.full,
     this.draggable = true,
     this.originateAboveBottomViewInset = false,
@@ -105,6 +106,9 @@ class StupidSimpleGlassSheetRoute<T> extends PopupRoute<T>
 
   @override
   final bool callNavigatorUserGestureMethods;
+
+  @override
+  final SheetDragHandoff dragHandoff;
 
   @override
   final SheetSnappingConfig snappingConfig;

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -154,7 +154,6 @@ class _RelativeGestureDetectorState extends State<_RelativeGestureDetector> {
   @override
   Widget build(BuildContext context) {
     return ScrollDragDetector(
-      leadingEdgeHandoff: ScrollDragHandoff.edge,
       trailingEdgeHandoff: widget.dragFromTrailingEdge
           ? ScrollDragHandoff.beforeScroll
           : ScrollDragHandoff.none,

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -18,6 +18,17 @@ export 'src/snapping_point.dart';
 export 'src/stupid_simple_cupertino_sheet.dart';
 export 'src/stupid_simple_glass_sheet.dart';
 
+/// Controls whether scrolling content can hand an active gesture to its sheet.
+enum SheetDragHandoff {
+  /// The sheet can only take over when the scrollable was already at its top
+  /// boundary when the gesture began.
+  gestureStart,
+
+  /// The sheet can take over after the same gesture scrolls the content to its
+  /// top boundary.
+  continuous,
+}
+
 /// A modal route that displays a sheet that slides up from the bottom.
 ///
 /// The sheet can be dismissed by dragging down or by tapping the barrier.
@@ -51,7 +62,7 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
     this.barrierDismissible = true,
     this.barrierLabel,
     this.clearBarrierImmediately = true,
-    this.onlyDragWhenScrollWasAtTop = true,
+    this.dragHandoff = SheetDragHandoff.gestureStart,
     this.callNavigatorUserGestureMethods = false,
     this.snappingConfig = SheetSnappingConfig.full,
     this.draggable = true,
@@ -79,7 +90,7 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
   final bool clearBarrierImmediately;
 
   @override
-  final bool onlyDragWhenScrollWasAtTop;
+  final SheetDragHandoff dragHandoff;
 
   @override
   final bool callNavigatorUserGestureMethods;
@@ -122,7 +133,7 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
 class _RelativeGestureDetector extends StatefulWidget {
   const _RelativeGestureDetector({
     required this.dragFromTrailingEdge,
-    required this.onlyDragWhenScrollWasAtTop,
+    required this.dragHandoff,
     required this.onRelativeDragStart,
     required this.onRelativeDragUpdate,
     required this.onRelativeDragEnd,
@@ -131,7 +142,7 @@ class _RelativeGestureDetector extends StatefulWidget {
   });
 
   final bool dragFromTrailingEdge;
-  final bool onlyDragWhenScrollWasAtTop;
+  final SheetDragHandoff dragHandoff;
   final VoidCallback onRelativeDragStart;
   // ignore: avoid_positional_boolean_parameters
   final void Function(double delta, double referenceHeight, bool wouldScroll)
@@ -154,10 +165,15 @@ class _RelativeGestureDetectorState extends State<_RelativeGestureDetector> {
   @override
   Widget build(BuildContext context) {
     return ScrollDragDetector(
-      trailingEdgeHandoff: widget.dragFromTrailingEdge
-          ? ScrollDragHandoff.beforeScroll
-          : ScrollDragHandoff.none,
-      onlyDragWhenScrollWasAtLeadingEdge: widget.onlyDragWhenScrollWasAtTop,
+      up: widget.dragFromTrailingEdge
+          ? ScrollDragMode.dragFirst
+          : ScrollDragMode.none,
+      down: switch (widget.dragHandoff) {
+        SheetDragHandoff.gestureStart => ScrollDragMode.boundaryStart,
+        SheetDragHandoff.continuous => ScrollDragMode.scrollFirst,
+      },
+      left: ScrollDragMode.none,
+      right: ScrollDragMode.none,
       onVerticalDragStart: (details, _) {
         _referenceHeight = SheetDismissalTransition.referenceHeightOf(
           context,
@@ -227,16 +243,11 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
   /// {@endtemplate}
   bool get clearBarrierImmediately => true;
 
-  /// {@template onlyDragWhenScrollWasAtTop}
-  /// Whether the sheet should only start being draggable when its scrollable
-  /// content was at the top whenever the user initiates a drag.
+  /// Controls whether scrolling content can hand an active gesture to this
+  /// sheet.
   ///
-  /// If this is true, and the user starts scrolling up from somewhere other
-  /// than the top, the scroll view will perform a normal overscroll.
-  ///
-  /// This matches iOS sheet behavior and defaults to true.
-  /// {@endtemplate}
-  bool get onlyDragWhenScrollWasAtTop => true;
+  /// Defaults to [SheetDragHandoff.gestureStart], matching iOS sheet behavior.
+  SheetDragHandoff get dragHandoff => SheetDragHandoff.gestureStart;
 
   /// Whether the sheet can be dragged.
   ///
@@ -426,7 +437,7 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
         // sure the content inside the sheet doesn't add extra padding
         child: _RelativeGestureDetector(
           dismissalMode: dismissalMode,
-          onlyDragWhenScrollWasAtTop: onlyDragWhenScrollWasAtTop,
+          dragHandoff: dragHandoff,
           dragFromTrailingEdge: (_animationTargetValue ?? animation.value) <
               effectiveSnappingConfig.maxExtent,
           onRelativeDragStart: () => _handleDragStart(context),

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -173,7 +173,9 @@ class _RelativeGestureDetectorState extends State<_RelativeGestureDetector> {
             willScroll,
           );
         }
-        _referenceHeight = null;
+        if (!willScroll) {
+          _referenceHeight = null;
+        }
       },
       onVerticalDragUpdate: (details, wouldScroll) {
         if (_referenceHeight case final height?) {
@@ -575,7 +577,6 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
     bool willScroll,
   ) {
     _isUserDragging = false;
-    final currentValue = controller!.value;
     if (callNavigatorUserGestureMethods) {
       navigator?.didStopUserGesture();
     }
@@ -583,6 +584,15 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
     // If the route has been popped, don't interfere with the closing animation
     if (_poppedNotifier.value) return;
 
+    // The scrollable is taking over this gesture. Keep the sheet where it is
+    // until a later drag segment ends without handing control back.
+    if (willScroll) {
+      _dragEndVelocity = null;
+      _updateSnapshotState();
+      return;
+    }
+
+    final currentValue = controller!.value;
     _dragEndVelocity = velocity;
 
     final maxExtent = effectiveSnappingConfig.maxExtent;

--- a/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
+++ b/packages/stupid_simple_sheet/lib/stupid_simple_sheet.dart
@@ -121,7 +121,7 @@ class StupidSimpleSheetRoute<T> extends PopupRoute<T>
 
 class _RelativeGestureDetector extends StatefulWidget {
   const _RelativeGestureDetector({
-    required this.scrollableCanMoveBack,
+    required this.dragFromTrailingEdge,
     required this.onlyDragWhenScrollWasAtTop,
     required this.onRelativeDragStart,
     required this.onRelativeDragUpdate,
@@ -130,7 +130,7 @@ class _RelativeGestureDetector extends StatefulWidget {
     required this.child,
   });
 
-  final bool scrollableCanMoveBack;
+  final bool dragFromTrailingEdge;
   final bool onlyDragWhenScrollWasAtTop;
   final VoidCallback onRelativeDragStart;
   // ignore: avoid_positional_boolean_parameters
@@ -154,8 +154,11 @@ class _RelativeGestureDetectorState extends State<_RelativeGestureDetector> {
   @override
   Widget build(BuildContext context) {
     return ScrollDragDetector(
-      onlyDragWhenScrollWasAtTop: widget.onlyDragWhenScrollWasAtTop,
-      scrollableCanMoveBack: widget.scrollableCanMoveBack,
+      leadingEdgeHandoff: ScrollDragHandoff.edge,
+      trailingEdgeHandoff: widget.dragFromTrailingEdge
+          ? ScrollDragHandoff.beforeScroll
+          : ScrollDragHandoff.none,
+      onlyDragWhenScrollWasAtLeadingEdge: widget.onlyDragWhenScrollWasAtTop,
       onVerticalDragStart: (details, _) {
         _referenceHeight = SheetDismissalTransition.referenceHeightOf(
           context,
@@ -423,7 +426,7 @@ mixin StupidSimpleSheetTransitionMixin<T> on PopupRoute<T> {
         child: _RelativeGestureDetector(
           dismissalMode: dismissalMode,
           onlyDragWhenScrollWasAtTop: onlyDragWhenScrollWasAtTop,
-          scrollableCanMoveBack: (_animationTargetValue ?? animation.value) <
+          dragFromTrailingEdge: (_animationTargetValue ?? animation.value) <
               effectiveSnappingConfig.maxExtent,
           onRelativeDragStart: () => _handleDragStart(context),
           onRelativeDragUpdate: (relativeDelta, referenceHeight, wouldScroll) =>

--- a/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
+++ b/packages/stupid_simple_sheet/test/stupid_simple_sheet_test.dart
@@ -22,7 +22,7 @@ void main() {
 
     Widget build({
       Motion motion = motion,
-      bool onlyDragWhenScrollWasAtTop = true,
+      SheetDragHandoff dragHandoff = SheetDragHandoff.gestureStart,
       bool draggable = true,
       bool originateAboveBottomViewInset = false,
     }) {
@@ -39,7 +39,7 @@ void main() {
                   ).push(
                     StupidSimpleSheetRoute<void>(
                       motion: motion,
-                      onlyDragWhenScrollWasAtTop: onlyDragWhenScrollWasAtTop,
+                      dragHandoff: dragHandoff,
                       draggable: draggable,
                       originateAboveBottomViewInset:
                           originateAboveBottomViewInset,
@@ -133,8 +133,8 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     });
 
-    testWidgets('only drags when started at top', (tester) async {
-      await tester.pumpWidget(build(onlyDragWhenScrollWasAtTop: true));
+    testWidgets('gestureStart only drags when started at top', (tester) async {
+      await tester.pumpWidget(build());
       await tester.tap(find.byKey(const ValueKey('button')));
       await tester.pumpAndSettle();
       final scaffoldFinder = find.byKey(const ValueKey('scaffold'));
@@ -165,9 +165,11 @@ void main() {
       expect(find.byType(GlowingOverscrollIndicator), findsOneWidget);
     });
 
-    testWidgets('drags from anywhere if onlyDragWhenScrollWasAtTop is false',
+    testWidgets('continuous handoff drags after scrolling to the top',
         (tester) async {
-      await tester.pumpWidget(build(onlyDragWhenScrollWasAtTop: false));
+      await tester.pumpWidget(
+        build(dragHandoff: SheetDragHandoff.continuous),
+      );
       await tester.tap(find.byKey(const ValueKey('button')));
       await tester.pumpAndSettle();
       final scaffoldFinder = find.byKey(const ValueKey('scaffold'));
@@ -599,7 +601,7 @@ void main() {
       DismissalMode dismissalMode = DismissalMode.slide,
       Widget? sheetChild,
       bool draggable = true,
-      bool onlyDragWhenScrollWasAtTop = true,
+      SheetDragHandoff dragHandoff = SheetDragHandoff.gestureStart,
       SheetSnappingConfig snappingConfig = SheetSnappingConfig.full,
     }) {
       return MaterialApp(
@@ -616,7 +618,7 @@ void main() {
                       dismissalMode: dismissalMode,
                       draggable: draggable,
                       snappingConfig: snappingConfig,
-                      onlyDragWhenScrollWasAtTop: onlyDragWhenScrollWasAtTop,
+                      dragHandoff: dragHandoff,
                       child: sheetChild ??
                           const ColoredBox(
                             key: ValueKey('sheet'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Replace the bottom-sheet-specific scroll handoff flags with required `up`, `down`, `left`, and `right` physical routing modes. Each direction independently chooses child-only, drag-first, scroll-first, or boundary-at-gesture-start behavior; routing and drag state are tracked per axis and work with reversed scrollables.

Add `ScrollDragDetector.legacy` as an explicit migration constructor for the old `scrollableCanMoveBack` and `onlyDragWhenScrollWasAtTop` configuration. Migrate every `stupid_simple_sheet` route to the new API and replace its old boolean with the clearer `dragHandoff` setting.

This also supports scroll-first trailing-boundary takeover, live mode changes, repeated same-gesture reversal, physical release velocities, and tracked-axis isolation for issue #313.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5490cc-aef8-429c-9f44-59434fa0139b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5490cc-aef8-429c-9f44-59434fa0139b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

