### PR TITLE
feat(stupid_simple_sheet): add deprecated legacy snap physics

### DIFF
--- a/packages/stupid_simple_sheet/CHANGELOG.md
+++ b/packages/stupid_simple_sheet/CHANGELOG.md
@@ -4,6 +4,8 @@
    `dragHandoff` on every sheet route.
  - **FIX**: migrate scroll-to-drag routing to the physical-direction
    `scroll_drag_detector` API.
+ - **DEPRECATE**: add `LegacySnapPhysics` for migrations that need the
+   pre-`1.0.0-dev.1` snapping response.
 
 ## 1.0.0-dev.2
 

--- a/packages/stupid_simple_sheet/README.md
+++ b/packages/stupid_simple_sheet/README.md
@@ -178,6 +178,19 @@ Navigator.of(context).push(
 );
 ```
 
+If you are migrating from a pre-`1.0.0-dev.1` release and need to preserve
+its snap response, opt into the deprecated compatibility physics:
+
+```dart
+SheetSnappingConfig(
+  [0.5, 1.0],
+  physics: LegacySnapPhysics(),
+);
+```
+
+New code should use the default `FlingSnapPhysics` or opt into
+`FrictionSnapPhysics`.
+
 You can dynamically change snapping at runtime from inside the sheet:
 
 ```dart

--- a/packages/stupid_simple_sheet/lib/src/snapping_point.dart
+++ b/packages/stupid_simple_sheet/lib/src/snapping_point.dart
@@ -338,6 +338,10 @@ class FrictionSnapPhysics extends RelativeSnapPhysics {
 )
 class LegacySnapPhysics extends RelativeSnapPhysics {
   /// Creates legacy snap physics.
+  @Deprecated(
+    'Use FlingSnapPhysics or FrictionSnapPhysics instead. '
+    'This behavior is retained for migration compatibility.',
+  )
   const LegacySnapPhysics();
 
   @override

--- a/packages/stupid_simple_sheet/lib/src/snapping_point.dart
+++ b/packages/stupid_simple_sheet/lib/src/snapping_point.dart
@@ -321,3 +321,36 @@ class FrictionSnapPhysics extends RelativeSnapPhysics {
     return findClosestPoint(snapPoints, projectedPosition);
   }
 }
+
+/// Restores the snap-point behavior used before `1.0.0-dev.1`.
+///
+/// This physics treats velocities below `0.5` normalized units as a regular
+/// drag. Faster gestures project the current position by `velocity * 0.3` and
+/// settle on the closest snap point. The velocity is normalized so positive
+/// values move the sheet towards its open state.
+///
+/// This behavior is retained for migrations where changing the snap response
+/// would be undesirable. New sheets should use [FlingSnapPhysics] or
+/// [FrictionSnapPhysics] instead.
+@Deprecated(
+  'Use FlingSnapPhysics or FrictionSnapPhysics instead. '
+  'This behavior is retained for migration compatibility.',
+)
+class LegacySnapPhysics extends RelativeSnapPhysics {
+  /// Creates legacy snap physics.
+  const LegacySnapPhysics();
+
+  @override
+  double findTargetSnapPoint({
+    required double position,
+    required double velocity,
+    required List<double> snapPoints,
+  }) {
+    if (velocity.abs() <= 0.5) {
+      return findClosestPoint(snapPoints, position);
+    }
+
+    final projectedPosition = position + velocity * 0.3;
+    return findClosestPoint(snapPoints, projectedPosition);
+  }
+}

--- a/packages/stupid_simple_sheet/test/snap_physics_test.dart
+++ b/packages/stupid_simple_sheet/test/snap_physics_test.dart
@@ -196,6 +196,42 @@ void main() {
     });
   });
 
+  group('LegacySnapPhysics', () {
+    // ignore: deprecated_member_use
+    const physics = LegacySnapPhysics();
+    final snapPoints = [0.0, 0.3, 0.6, 1.0];
+
+    test('uses closest-point snapping below the legacy fling threshold', () {
+      final result = physics.findTargetSnapPoint(
+        position: 0.4,
+        velocity: 0.5,
+        snapPoints: snapPoints,
+      );
+
+      expect(result, 0.3);
+    });
+
+    test('projects fast opening gestures using legacy scaling', () {
+      final result = physics.findTargetSnapPoint(
+        position: 0.4,
+        velocity: 2,
+        snapPoints: snapPoints,
+      );
+
+      expect(result, 1.0);
+    });
+
+    test('projects fast closing gestures using legacy scaling', () {
+      final result = physics.findTargetSnapPoint(
+        position: 0.4,
+        velocity: -2,
+        snapPoints: snapPoints,
+      );
+
+      expect(result, 0.0);
+    });
+  });
+
   group('SheetSnappingConfig', () {
     group('findClosestSnapPoint', () {
       test('finds closest point ignoring velocity', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add `LegacySnapPhysics`, marked deprecated, to restore the pre-`1.0.0-dev.1` snap-point projection and threshold for migrations that must preserve existing sheet behavior. Document the migration option and cover threshold, opening, and closing projections with tests.

This PR is stacked on the physical directional-routing work in [PR #314](https://github.com/whynotmake-it/rivership/pull/314) and includes its latest `ScrollDragMode`, `ScrollDragDetector.legacy`, and sheet `dragHandoff` API.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5490cc-aef8-429c-9f44-59434fa0139b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5490cc-aef8-429c-9f44-59434fa0139b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

